### PR TITLE
Fix: Correct import names from DataFetchingService in ResearchAgent

### DIFF
--- a/src/agents/ResearchAgent.ts
+++ b/src/agents/ResearchAgent.ts
@@ -4,8 +4,8 @@ import { ValidationService } from '../services/ValidationService';
 import { ConfidenceScorer } from '../services/ConfidenceScorer';
 import { ragDatabase } from '../db/EnhancedVectorDatabase'; // Direct import for now
 import {
-  fetchCVEDataInternal,
-  fetchEPSSDataInternal,
+  fetchCVEData,
+  fetchEPSSData,
 } from '../services/DataFetchingService';
 import {
   fetchPatchesAndAdvisories,
@@ -45,8 +45,8 @@ export class ResearchAgent {
 
     this.updateSteps(`🔍 Agent fetching primary data (NVD, EPSS) for ${cveId}...`);
     const [cveResult, epssResult] = await Promise.allSettled([
-        fetchCVEDataInternal(cveId, apiKeys.nvd, this.setLoadingSteps, ragDatabase, fetchWithFallback, processCVEData),
-        fetchEPSSDataInternal(cveId, this.setLoadingSteps, ragDatabase, fetchWithFallback)
+        fetchCVEData(cveId, apiKeys.nvd, this.setLoadingSteps, ragDatabase, fetchWithFallback, processCVEData),
+        fetchEPSSData(cveId, this.setLoadingSteps, ragDatabase, fetchWithFallback)
     ]);
 
     const cve = cveResult.status === 'fulfilled' ? cveResult.value : null;


### PR DESCRIPTION
Corrected the import names for `fetchCVEData` and `fetchEPSSData` from `DataFetchingService.ts` within `ResearchAgent.ts`.

This resolves errors caused by attempting to import these functions with an `Internal` suffix (e.g., `fetchCVEDataInternal`). The function calls within the agent have also been updated to use the correct non-suffixed names.