### PR TITLE
fix: Correct import syntax in UserAssistantAgent.ts

### DIFF
--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -1,5 +1,5 @@
 import { APIService } from '../services/APIService';
-import { AppContext } // Assuming settings might come from AppContext
+import { AppContext } from '../contexts/AppContext'; // Assuming settings might come from AppContext
 // We might need to import specific types for vulnerability data if we strongly type responses.
 // For now, we'll keep it simple and return strings or simple objects.
 


### PR DESCRIPTION
This addresses a vite/esbuild transform error caused by an incomplete import statement for AppContext.

Previous commit was:
feat: Implement React-based chatbot interface for CVE inquiries

- Remove previous Python-based chatbot files.
- Add UserAssistantAgent.ts to manage conversation flow and orchestrate backend calls.
- Create ChatInterface.tsx component for user interaction.
- Integrate ChatInterface into App.tsx as the primary UI.
- Users can now set a CVE context and ask questions about EPSS scores, exploits, summaries, and patches/advisories in a conversational manner.