### PR TITLE
fix: Correct import syntax in ChatInterface.tsx

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -4,7 +4,7 @@ import { AppContext } from '../contexts/AppContext';
 import { UserAssistantAgent } from '../agents/UserAssistantAgent';
 import { utils } from '../utils/helpers'; // For CVE validation
 import { createStyles } from '../utils/styles';
-import { COLORS }_from '../utils/constants';
+import { COLORS } from '../utils/constants';
 
 interface Message {
   id: string;


### PR DESCRIPTION
This addresses a vite/esbuild transform error caused by a typo in the import statement for COLORS.

Previous commits were:
fix: Correct import syntax in UserAssistantAgent.ts feat: Implement React-based chatbot interface for CVE inquiries