### PR TITLE
Add explicit interfaces and strict tsconfig

### DIFF
--- a/src/agents/RAGCuratorAgent.ts
+++ b/src/agents/RAGCuratorAgent.ts
@@ -2,6 +2,7 @@
 import { ragDatabase } from '../db/EnhancedVectorDatabase';
 import { ResearchAgent } from './ResearchAgent'; // To trigger re-analysis
 import { APIService } from '../services/APIService'; // Or use APIService to trigger ResearchAgent indirectly
+import { AgentSettings, ConflictingInfo } from '../types/cveData';
 
 export class RAGCuratorAgent {
   private researchAgent: ResearchAgent; // For triggering re-analysis
@@ -59,7 +60,11 @@ export class RAGCuratorAgent {
    * @param apiKeys API keys needed for the ResearchAgent.
    * @param settings Settings needed for the ResearchAgent.
    */
-  async triggerReanalysis(cveId: string, apiKeys: { nvd?: string; geminiApiKey?: string }, settings: any): Promise<boolean> {
+  async triggerReanalysis(
+    cveId: string,
+    apiKeys: { nvd?: string; geminiApiKey?: string },
+    settings: AgentSettings
+  ): Promise<boolean> {
     console.log(`RAG Curator: Triggering re-analysis for ${cveId}...`);
     try {
       // Option 1: Directly use the researchAgent instance
@@ -80,7 +85,7 @@ export class RAGCuratorAgent {
   }
 
   // Placeholder for future task: Identify conflicting information
-  async identifyConflictingInfo(cveId: string): Promise<any[]> {
+  async identifyConflictingInfo(cveId: string): Promise<ConflictingInfo[]> {
     console.log(`RAG Curator: Identifying conflicting info for ${cveId} (Not Implemented Yet)...`);
     // 1. Search RAG for all documents related to cveId.
     // 2. Analyze content of these documents (e.g., looking for contradictory statements on severity, KEV status, patch availability).
@@ -90,7 +95,11 @@ export class RAGCuratorAgent {
   }
 
   // Main method to run curation tasks (can be expanded)
-  async runCurationCycle(apiKeys: { nvd?: string; geminiApiKey?: string }, settings: any, maxAgeDays: number = 30) {
+  async runCurationCycle(
+    apiKeys: { nvd?: string; geminiApiKey?: string },
+    settings: AgentSettings,
+    maxAgeDays: number = 30
+  ) {
     console.log("RAG Curator: Starting curation cycle...");
     const outdated = await this.identifyOutdatedSummaries(maxAgeDays);
     for (const cveId of outdated) {

--- a/src/services/FileParserService.ts
+++ b/src/services/FileParserService.ts
@@ -49,6 +49,7 @@ export async function extractCVEsFromCSV(file: File): Promise<string[]> {
 }
 
 import * as pdfjsLib from 'pdfjs-dist/build/pdf';
+import { PDFTextItem } from '../types/pdf';
 // You might need to configure the worker path depending on your bundler.
 // For Vite, often it can resolve this, or you might need:
 // import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.entry';
@@ -116,7 +117,7 @@ export async function extractCVEsFromPDF(file: File): Promise<string[]> {
         for (let i = 1; i <= pdf.numPages; i++) {
           const page = await pdf.getPage(i);
           const textContent = await page.getTextContent();
-          const pageText = textContent.items.map(item => (item as any).str).join(' '); // item.str is the text
+          const pageText = textContent.items.map(item => (item as PDFTextItem).str).join(' ');
           allTextContent += pageText + "\n";
         }
 
@@ -164,7 +165,7 @@ export async function extractCVEsFromXLSX(file: File): Promise<string[]> {
           const worksheet = workbook.Sheets[sheetName];
           // Convert sheet to an array of arrays (rows) of cell values
           // XLSX.utils.sheet_to_json with header:1 converts to array of arrays
-          const sheetData: any[][] = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: "" });
+          const sheetData: unknown[][] = XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: "" });
 
           sheetData.forEach(row => {
             row.forEach(cell => {

--- a/src/services/ValidationService.ts
+++ b/src/services/ValidationService.ts
@@ -2,37 +2,20 @@
 import {
   CVEValidationData,
   BaseCVEInfo,
-  PatchInfo, // Ensure this is correctly imported if defined in cveData.ts
-  AdvisoryInfo, // Ensure this is correctly imported
-  // Import other necessary types like AIThreatIntelData (actual name may vary), PatchData
-  // For now, using 'any' for undefined complex types from other services.
+  PatchInfo,
+  AdvisoryInfo,
+  PatchData,
 } from '../types/cveData';
+import { AIThreatIntelData } from '../types/aiThreatIntel';
 import { APIService } from './APIService'; // Assuming APIService might be needed for some sub-fetches, though ideally data is passed in.
-
-// Placeholder for actual AI Intel and PatchData types
-// These should be replaced with their actual definitions from other parts of the application
-interface AIThreatIntelDataPlaceholder {
-  summary?: string;
-  technicalAnalysis?: { text?: string };
-  searchResults?: Array<{ snippet?: string; title?: string; url?: string }>; // Example structure
-  // Add other fields that might contain relevant text or structured info from AI
-  vendorDisputes?: Array<{ source: string; detail: string }>; // Example if AI can structure this
-  researcherOpinions?: Array<{ source: string; opinion: string; url: string }>; // Example
-}
-
-interface PatchDataPlaceholder {
-  patches?: Array<PatchInfo & { vendor: string; product?: string; downloadUrl?: string; advisoryUrl?: string; description?: string }>;
-  advisories?: Array<AdvisoryInfo & { source: string; url?: string; title?: string }>;
-  searchSummary?: any;
-}
 
 
 export class ValidationService {
   public static async validateAIFindings(
     cveId: string,
     nvdData: BaseCVEInfo | null,
-    aiIntel: AIThreatIntelDataPlaceholder | null, // Using placeholder
-    patchAdvisoryData: PatchDataPlaceholder | null, // Using placeholder
+    aiIntel: AIThreatIntelData | null,
+    patchAdvisoryData: PatchData | null,
   ): Promise<CVEValidationData> {
 
     const validationOutput: CVEValidationData = {
@@ -228,7 +211,7 @@ export class ValidationService {
     return validationOutput;
   }
 
-  private static extractTextFromAIIntel(aiIntel: AIThreatIntelDataPlaceholder): string {
+  private static extractTextFromAIIntel(aiIntel: AIThreatIntelData): string {
     let text = '';
     if (aiIntel?.summary) text += aiIntel.summary.toLowerCase() + ' ';
     if (aiIntel?.technicalAnalysis?.text) text += aiIntel.technicalAnalysis.text.toLowerCase() + ' ';

--- a/src/types/aiThreatIntel.ts
+++ b/src/types/aiThreatIntel.ts
@@ -1,0 +1,27 @@
+import {
+  CisaKevDetails,
+  ActiveExploitationData,
+  ExploitDiscoveryData,
+  VendorAdvisoryData,
+  TechnicalAnalysisData,
+  ThreatIntelligenceData,
+  IntelligenceSummary,
+  HallucinationFlag,
+  ExtractionMetadata,
+} from './cveData';
+
+export interface AIThreatIntelData {
+  cisaKev?: CisaKevDetails;
+  activeExploitation?: ActiveExploitationData;
+  exploitDiscovery?: ExploitDiscoveryData;
+  vendorAdvisories?: VendorAdvisoryData;
+  technicalAnalysis?: TechnicalAnalysisData;
+  threatIntelligence?: ThreatIntelligenceData;
+  searchResults?: Array<{ snippet?: string; title?: string; url?: string }>;
+  intelligenceSummary?: IntelligenceSummary;
+  overallThreatLevel?: string;
+  lastUpdated?: string;
+  summary?: string;
+  hallucinationFlags?: Array<HallucinationFlag | string>;
+  extractionMetadata?: ExtractionMetadata | Record<string, unknown>;
+}

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -298,6 +298,20 @@ export interface ExtractionMetadata {
   errors?: string[]; // Any errors during extraction from this source
 }
 
+export interface InformationSource {
+  name: string;
+  url?: string;
+  type?: string;
+  aiDiscovered?: boolean;
+  [key: string]: any;
+}
+
+export interface ConflictingInfo {
+  field: string;
+  details: string;
+  sources?: string[];
+}
+
 
 // --- CVEValidationData for Legitimacy Analysis ---
 export interface AdvisoryInfo { // Duplicated for now, consider moving to a shared types location if not already
@@ -378,7 +392,7 @@ export interface EnhancedVulnerabilityData {
   advisories?: VendorAdvisory[]; // Direct advisory info (might be duplicated if also in vendorAdvisories)
   patchSearchSummary?: PatchSearchSummary;
 
-  sources?: Array<{name: string; url?: string; type?: string; [key: string]: any}>; // List of all information sources used
+  sources?: InformationSource[]; // List of all information sources used
   discoveredSources?: string[]; // Names of sources AI found data in
 
   summary?: string; // Overall AI-generated summary of the CVE

--- a/src/types/pdf.ts
+++ b/src/types/pdf.ts
@@ -1,0 +1,4 @@
+export interface PDFTextItem {
+  str: string;
+  [key: string]: unknown;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- introduce `AIThreatIntelData` and `PDFTextItem` interfaces
- use `InformationSource` and `ConflictingInfo` in data models
- tighten types in agents and services
- replace remaining `any` casts
- add `tsconfig.json` with strict settings

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862adbbed4c832cb1300f08de284ccc