### PR TITLE
Improve chatbot fallback

### DIFF
--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -33,6 +33,7 @@ import {
   fetchPatchesAndAdvisories as fetchPatchesAndAdvisoriesInternal,
   fetchAIThreatIntelligence as fetchAIThreatIntelligenceInternal,
   generateAIAnalysis as generateAIAnalysisInternal,
+  fetchGeneralAnswer as fetchGeneralAnswerInternal,
 } from './AIEnhancementService';
 
 
@@ -59,6 +60,10 @@ export class APIService {
 
   static async generateAIAnalysis(vulnerability, apiKey, model, settings = {}) {
     return generateAIAnalysisInternal(vulnerability, apiKey, model, settings, ragDatabase, fetchWithFallback, buildEnhancedAnalysisPrompt, generateEnhancedFallbackAnalysis);
+  }
+
+  static async fetchGeneralAnswer(query, settings = {}) {
+    return fetchGeneralAnswerInternal(query, settings, fetchWithFallback);
   }
 
 


### PR DESCRIPTION
## Summary
- add general search capability in `AIEnhancementService`
- expose this new function via `APIService`
- use AI search fallback in `UserAssistantAgent`
- update dependencies to run tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862b3333278832c95f53d39c2f44e0a