### PR TITLE
Add bulk analysis rate limit delay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,8 @@ const App = () => {
   const startBulkAnalysis = async (cveIds: string[]) => {
     if (isBulkLoading) return;
 
+    const delayMs = 1500; // throttle to avoid hitting API rate limits
+
     setIsBulkLoading(true);
     setBulkAnalysisResults([]);
     setBulkProgress({ current: 0, total: cveIds.length });
@@ -98,6 +100,8 @@ const App = () => {
       // Update results incrementally or all at once at the end.
       // For now, updating incrementally to show progress.
       setBulkAnalysisResults([...results]);
+
+      await utils.sleep(delayMs);
     }
 
     setIsBulkLoading(false);

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -46,5 +46,7 @@ export const utils = {
       clearTimeout(timeout);
       timeout = setTimeout(later, wait);
     };
-  }
+  },
+
+  sleep: (ms) => new Promise(resolve => setTimeout(resolve, ms))
 };


### PR DESCRIPTION
## Summary
- prevent API rate limiting for bulk analysis
- add `utils.sleep` helper and delay between CVE requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b959a214832c8f85f2a3e5c951b1