### PR TITLE
Clarify dispute status in validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ AFTER:  Real-time, web-grounded security intelligence
 - **Predictive Risk Assessment**: AI-powered exploitation probability
 - **Contextual Understanding**: Business impact analysis
 - **Continuous Learning**: RAG system improves with each analysis
+- **Hallucination Detection**: Flags suspicious AI-generated data with confidence indicators
+- **Comprehensive CVE Validation**: Cross-checks NVD, vendor advisories and security research; disputed CVEs are clearly flagged
 
 ### **3. 📈 Executive Decision Support**
 ```

--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -820,14 +820,19 @@ const CVEDetailView = ({ vulnerability }) => {
                                 Legitimacy Score: {validation.legitimacyScore ?? 'N/A'} / 100
                                 {' • '}
                                 Confidence: {validation.confidence || 'N/A'}
-                                {validation.validationSources?.length > 0 && ` • ${validation.validationSources.length} sources checked`}
+                                {validation.validationSources?.length > 0 && ` • Sources: ${validation.validationSources.join(', ')}`}
                               </p>
                             </div>
                           </div>
-                          <div style={{ fontSize: '0.95rem', lineHeight: '1.6', marginBottom: '12px' }}>
+                           <div style={{ fontSize: '0.95rem', lineHeight: '1.6', marginBottom: '12px' }}>
                              <strong>Summary:</strong> {validation.legitimacySummary || validation.recommendation || 'No detailed summary available.'}
-                          </div>
-                           <div style={{ fontSize: '0.8rem', color: settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
+                           </div>
+                           {validation.status === 'DISPUTED' && (
+                             <div style={{ fontSize: '0.9rem', color: COLORS.yellow, marginBottom: '8px' }}>
+                               ⚠ This vulnerability is disputed
+                             </div>
+                           )}
+                            <div style={{ fontSize: '0.8rem', color: settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
                              Last Assessed: {validation.lastUpdated ? new Date(validation.lastUpdated).toLocaleString() : 'N/A'}
                            </div>
                         </div>
@@ -916,6 +921,19 @@ const CVEDetailView = ({ vulnerability }) => {
                            <div style={{...styles.card, background: settings.darkMode ? COLORS.dark.background : COLORS.light.background, marginTop: '20px'}}>
                               <h4 style={{fontSize: '1rem', fontWeight: '600', color: COLORS.red}}>Original Dispute Records</h4>
                               {validation.disputes.map((d, i) => <p key={i} style={{fontSize:'0.85rem'}}>Source: {d.source}, Reason: {d.reason}</p>)}
+                           </div>
+                        )}
+
+                        {vulnerability.hallucinationFlags && vulnerability.hallucinationFlags.length > 0 && (
+                           <div style={{...styles.card, background: settings.darkMode ? COLORS.dark.surface : COLORS.light.surface, marginTop: '20px'}}>
+                              <h4 style={{fontSize: '1rem', fontWeight: '600', color: COLORS.yellow}}>AI Hallucination Flags</h4>
+                              <ul style={{margin: '4px 0 0 20px', padding: 0, fontSize: '0.85rem', lineHeight: '1.6'}}>
+                                {vulnerability.hallucinationFlags.map((flag, i) => (
+                                  <li key={i}>
+                                    <strong>{flag.field || 'Field'}:</strong> {flag.suspectedReason || 'Potential issue'}{flag.confidence ? ` (Confidence: ${flag.confidence})` : ''}{flag.details ? ` - ${flag.details}` : ''}
+                                  </li>
+                                ))}
+                              </ul>
                            </div>
                         )}
                        </>


### PR DESCRIPTION
## Summary
- list sources consulted in the CVE validation summary
- show explicit disputed message when status is `DISPUTED`
- document comprehensive CVE validation in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863bac5083c832cbec81ae283552e63