### PR TITLE
Add ValidationAgent for CVE legitimacy analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ We've built the world's first **AI-Powered Real-Time Vulnerability Intelligence 
 Risk Score = f(CVSS, EPSS, KEV_Status, Threat_Intelligence, Business_Impact)
 ```
 
+### **🧩 Agents Overview**
+Our analysis workflow is composed of several cooperating agents:
+- **ResearchAgent** – gathers vulnerability intelligence and performs AI-driven searches.
+- **RAGCuratorAgent** – keeps the vector database fresh by re-analyzing stale summaries.
+- **ValidationAgent** – validates AI findings against trusted sources and stores the results.
+- **UserAssistantAgent** – conversational interface used by the chatbot and UI components.
+
 ---
 
 ## 🎯 **Key Features & Solutions**

--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../services/APIService', () => ({
+  APIService: {
+    fetchVulnerabilityDataWithAI: vi.fn().mockResolvedValue({
+      cve: { id: 'CVE-1234-0001' },
+      patches: [],
+      advisories: [],
+    })
+  }
+}));
+
+const mockValidation = { cveId: 'CVE-1234-0001', status: 'VALID' };
+const validateSpy = vi.fn().mockResolvedValue(mockValidation);
+vi.mock('./ValidationAgent', () => ({
+  ValidationAgent: vi.fn().mockImplementation(() => ({ validateCVE: validateSpy }))
+}));
+
+import { UserAssistantAgent } from './UserAssistantAgent';
+
+describe('UserAssistantAgent validation integration', () => {
+  it('uses ValidationAgent when handling validation queries', async () => {
+    const agent = new UserAssistantAgent({});
+    const res = await agent.handleQuery('validate CVE-1234-0001');
+    expect(validateSpy).toHaveBeenCalled();
+    expect(res.data).toEqual(mockValidation);
+  });
+});

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -1,4 +1,5 @@
 import { APIService } from '../services/APIService';
+import { ValidationAgent } from './ValidationAgent';
 import {
   AgentSettings,
   ChatResponse,
@@ -13,10 +14,6 @@ import {
   AISummaryData,
   PatchInfo, // For vendorConfirmation
   AdvisoryInfo, // For vendorConfirmation
-  CisaKevDetails,
-  ActiveExploitationData,
-  ExploitDiscoveryData,
-  AISummaryData,
   BulkAnalysisResult // Added for bulk analysis
 } from '../types/cveData';
 import { AIThreatIntelData } from '../types/aiThreatIntel';
@@ -418,10 +415,15 @@ export class UserAssistantAgent {
 
   private async getValidationInfo(cveId: string): Promise<ChatResponse<CVEValidationData | null>> {
     try {
-      // This call should now return EnhancedVulnerabilityData with the *new* CVEValidationData structure
-      const vulnerabilityData = await APIService.fetchVulnerabilityDataWithAI(cveId, () => {}, { nvd: this.settings?.nvdApiKey }, this.settings) as EnhancedVulnerabilityData | null;
+      // Retrieve vulnerability data to supply context for validation
+      const vulnerabilityData = await APIService.fetchVulnerabilityDataWithAI(
+        cveId,
+        () => {},
+        { nvd: this.settings?.nvdApiKey },
+        this.settings
+      ) as EnhancedVulnerabilityData | null;
 
-      if (!vulnerabilityData || !vulnerabilityData.cveValidation) {
+      if (!vulnerabilityData) {
         return {
           text: `I couldn't retrieve detailed validation and legitimacy information for ${cveId}. Basic CVE data might be missing or validation could not be performed.`,
           sender: 'bot',
@@ -431,7 +433,27 @@ export class UserAssistantAgent {
         };
       }
 
-      const validation = vulnerabilityData.cveValidation; // This should be our new detailed CVEValidationData
+      const validationAgent = new ValidationAgent();
+      const validation = await validationAgent.validateCVE(
+        cveId,
+        vulnerabilityData.cve,
+        {
+          cisaKev: vulnerabilityData.kev as CisaKevDetails,
+          activeExploitation: vulnerabilityData.activeExploitation as ActiveExploitationData,
+          exploitDiscovery: vulnerabilityData.exploits as ExploitDiscoveryData,
+          vendorAdvisories: vulnerabilityData.vendorAdvisories,
+          technicalAnalysis: vulnerabilityData.technicalAnalysis,
+          threatIntelligence: vulnerabilityData.threatIntelligence,
+          intelligenceSummary: vulnerabilityData.intelligenceSummary,
+          overallThreatLevel: vulnerabilityData.threatLevel,
+          hallucinationFlags: vulnerabilityData.hallucinationFlags,
+          extractionMetadata: vulnerabilityData.extractionMetadata,
+        } as AIThreatIntelData,
+        {
+          patches: vulnerabilityData.patches,
+          advisories: vulnerabilityData.advisories,
+        } as PatchData
+      );
       let responseText = `**Legitimacy Analysis for ${cveId}**:\n\n`;
 
       // Use the new legitimacySummary if available and informative

--- a/src/agents/ValidationAgent.test.ts
+++ b/src/agents/ValidationAgent.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ValidationAgent } from './ValidationAgent';
+import { ValidationService } from '../services/ValidationService';
+import type { CVEValidationData } from '../types/cveData';
+
+describe('ValidationAgent', () => {
+  it('returns validation data from ValidationService', async () => {
+    const sample: CVEValidationData = { cveId: 'CVE-0000-0000' } as CVEValidationData;
+    const spy = vi.spyOn(ValidationService, 'validateAIFindings').mockResolvedValue(sample);
+    const agent = new ValidationAgent();
+    const result = await agent.validateCVE('CVE-0000-0000', null, null, null);
+    expect(result).toBe(sample);
+    expect(spy).toHaveBeenCalledWith('CVE-0000-0000', null, null, null);
+    spy.mockRestore();
+  });
+});

--- a/src/agents/ValidationAgent.ts
+++ b/src/agents/ValidationAgent.ts
@@ -1,0 +1,50 @@
+import { ValidationService } from '../services/ValidationService';
+import { ragDatabase } from '../db/EnhancedVectorDatabase';
+import { BaseCVEInfo, PatchData, CVEValidationData } from '../types/cveData';
+import { AIThreatIntelData } from '../types/aiThreatIntel';
+
+export class ValidationAgent {
+  private setLoadingSteps: (stepsUpdater: (prev: string[]) => string[]) => void;
+
+  constructor(setLoadingSteps?: (stepsUpdater: (prev: string[]) => string[]) => void) {
+    this.setLoadingSteps = setLoadingSteps || (() => {});
+  }
+
+  private updateSteps(message: string) {
+    this.setLoadingSteps(prev => [...prev, message]);
+  }
+
+  public async validateCVE(
+    cveId: string,
+    nvdData: BaseCVEInfo | null,
+    aiIntel: AIThreatIntelData | null,
+    patchData: PatchData | null
+  ): Promise<CVEValidationData> {
+    this.updateSteps(`🛡️ Validation Agent processing ${cveId}...`);
+    const result = await ValidationService.validateAIFindings(
+      cveId,
+      nvdData,
+      aiIntel,
+      patchData
+    );
+    this.updateSteps(`✅ Validation complete for ${cveId}`);
+
+    if (ragDatabase?.initialized) {
+      try {
+        await ragDatabase.addDocument(
+          `Validation for ${cveId}: ${result.legitimacySummary || result.status}`,
+          {
+            title: `Validation - ${cveId}`,
+            category: 'validation-result',
+            cveId,
+            source: 'validation-agent',
+            timestamp: new Date().toISOString(),
+          }
+        );
+      } catch (err) {
+        console.warn('ValidationAgent failed to store result in RAG DB:', err);
+      }
+    }
+    return result;
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,4 @@
+export * from './ResearchAgent';
+export * from './RAGCuratorAgent';
+export * from './UserAssistantAgent';
+export * from './ValidationAgent';

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -175,10 +175,14 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ initialCveId }) => {
                 )}
               </div>
             </div>
-             {msg.sender === 'bot' && msg.data && (
+            {msg.sender === 'bot' && msg.data && (
               <div style={{ fontSize: '0.8rem', color: (settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText) || '#888', marginLeft: '32px', marginTop: '4px' }}>
-                {/* Potentially render some structured data here, or offer actions */}
-                {/* Example: <button onClick={() => alert(JSON.stringify(msg.data))}>View Raw Data</button> */}
+                {typeof msg.data.legitimacyScore === 'number' && (
+                  <span>Legitimacy Score: {msg.data.legitimacyScore}/100 </span>
+                )}
+                {msg.data.confidence && (
+                  <span style={{ marginLeft: '8px' }}>Confidence: {msg.data.confidence}</span>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add a `ValidationAgent` that wraps `ValidationService`
- integrate new agent into `UserAssistantAgent`
- expose agents via `src/agents/index.ts`
- display legitimacy score in chat UI
- document agents in README
- add unit tests for `ValidationAgent` and its chatbot integration
- fix duplicate imports in `UserAssistantAgent`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863cabea728832c985a7b8305cf4b29