### PR TITLE
Add tech brief display

### DIFF
--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -5,7 +5,8 @@ import { utils } from '../utils/helpers';
 import { createStyles } from '../utils/styles';
 import { COLORS, CONSTANTS } from '../utils/constants';
 import CVSSDisplay from './CVSSDisplay';
-import { Brain, Database, Globe, Info, Loader2, Copy, RefreshCw, Package, CheckCircle, XCircle, AlertTriangle, Target, ChevronRight } from 'lucide-react';
+import { Brain, Database, Globe, Info, Loader2, Copy, RefreshCw, Package, CheckCircle, XCircle, AlertTriangle, Target, ChevronRight, FileText } from 'lucide-react';
+import TechnicalBrief from './TechnicalBrief';
 import ScoreChart from './ScoreChart';
 
 const CVEDetailView = ({ vulnerability }) => {
@@ -268,7 +269,7 @@ const CVEDetailView = ({ vulnerability }) => {
           gap: '4px',
           flexWrap: 'wrap'
         }}>
-          {['overview', 'ai-sources', 'analysis'].map((tab) => (
+          {['overview', 'ai-sources', 'analysis', 'brief'].map((tab) => (
             <button
               key={tab}
               style={{
@@ -294,8 +295,14 @@ const CVEDetailView = ({ vulnerability }) => {
               {tab === 'overview' && <Info size={16} />}
               {tab === 'ai-sources' && <Globe size={16} />}
               {tab === 'analysis' && <Brain size={16} />}
-              {tab === 'ai-sources' ? 'AI Sources' :
-               tab === 'analysis' ? 'RAG Analysis' : tab.charAt(0).toUpperCase() + tab.slice(1)}
+              {tab === 'brief' && <FileText size={16} />}
+              {tab === 'ai-sources'
+                ? 'AI Sources'
+                : tab === 'analysis'
+                ? 'RAG Analysis'
+                : tab === 'brief'
+                ? 'Tech Brief'
+                : tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
           ))}
         </div>
@@ -815,6 +822,22 @@ const CVEDetailView = ({ vulnerability }) => {
                   <h3 style={{ margin: '16px 0 8px 0' }}>No AI Analysis Available</h3>
                   <p style={{ margin: 0, color: settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
                     Generate RAG-enhanced analysis to see structured insights
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'brief' && (
+            <div>
+              {aiAnalysis ? (
+                <TechnicalBrief brief={aiAnalysis.analysis} />
+              ) : (
+                <div style={{ textAlign: 'center', padding: '48px 32px' }}>
+                  <FileText size={40} color={settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText} />
+                  <h3 style={{ margin: '16px 0 8px 0' }}>No Technical Brief Available</h3>
+                  <p style={{ margin: 0, color: settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
+                    Generate RAG-enhanced analysis to view the technical brief
                   </p>
                 </div>
               )}

--- a/src/components/TechnicalBrief.tsx
+++ b/src/components/TechnicalBrief.tsx
@@ -1,0 +1,31 @@
+import React, { useContext, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { AppContext } from '../contexts/AppContext';
+import { createStyles } from '../utils/styles';
+import { COLORS } from '../utils/constants';
+
+interface TechnicalBriefProps {
+  brief: string | null | undefined;
+}
+
+const TechnicalBrief: React.FC<TechnicalBriefProps> = ({ brief }) => {
+  const { settings } = useContext(AppContext);
+  const styles = useMemo(() => createStyles(settings.darkMode), [settings.darkMode]);
+
+  if (!brief || brief.trim().length === 0) {
+    return (
+      <p style={{ fontSize: '0.875rem', color: settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
+        No technical brief available.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ ...styles.card, fontSize: '0.95rem', lineHeight: '1.7', whiteSpace: 'pre-wrap' }}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{brief}</ReactMarkdown>
+    </div>
+  );
+};
+
+export default TechnicalBrief;


### PR DESCRIPTION
## Summary
- show new `Tech Brief` tab in CVE detail view
- render AI-provided brief with markdown support

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68654b8fd35c832cb28cc5e86406b07c