### PR TITLE
Fix patch tab refresh

### DIFF
--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -30,7 +30,13 @@ const CVEDetailView = ({ vulnerability }) => {
     try {
       let enhancedVulnerability = vulnerability;
 
-      if (!vulnerability.aiSearchPerformed || !vulnerability.sources || vulnerability.sources.length === 0) {
+      if (
+        !vulnerability.aiSearchPerformed ||
+        !vulnerability.sources ||
+        vulnerability.sources.length === 0 ||
+        !vulnerability.patches ||
+        vulnerability.patches.length === 0
+      ) {
         addNotification({
           type: 'info',
           title: 'Performing AI Discovery',


### PR DESCRIPTION
## Summary
- refresh vulnerability data when AI analysis is generated if patches are missing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686560aef124832ca31283cea63b7272