### PR TITLE
Add RiskAssessmentAgent and vendor patch tab

### DIFF
--- a/src/agents/RiskAssessmentAgent.test.ts
+++ b/src/agents/RiskAssessmentAgent.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { RiskAssessmentAgent, RiskAssessmentInput } from './RiskAssessmentAgent';
+
+describe('RiskAssessmentAgent', () => {
+  it('formats risk assessment output', () => {
+    const input: RiskAssessmentInput = {
+      cvssScore: 8.0,
+      epssScore: 0.75,
+      cisaKevStatus: 'YES',
+      exploitsKnown: 'YES',
+      vulnerabilityId: 'CVE-2017-1000251',
+      patchInfo: 'Patch Available, Released: 2017-09-30',
+      businessPriority: 'P2 – Next sprint priority for engineering',
+      threatIntelConfidence: 'High – Multiple authoritative sources: CERT, vendor, GitHub'
+    };
+
+    const result = RiskAssessmentAgent.generateAssessment(input);
+    expect(result.text).toContain('AI Risk Assessment Results');
+    expect(result.text).toContain('# CVE-2017-1000251 Technical Brief');
+    expect(result.text).toContain('Patch Available');
+  });
+});

--- a/src/agents/RiskAssessmentAgent.ts
+++ b/src/agents/RiskAssessmentAgent.ts
@@ -1,0 +1,35 @@
+export interface RiskAssessmentInput {
+  cvssScore: number;
+  epssScore: number;
+  cisaKevStatus: 'YES' | 'NO';
+  exploitsKnown: 'YES' | 'NO';
+  vulnerabilityId: string;
+  patchInfo: string;
+  businessPriority: string;
+  threatIntelConfidence: string;
+}
+
+export interface RiskAssessmentResult {
+  text: string;
+}
+
+export class RiskAssessmentAgent {
+  static generateAssessment(input: RiskAssessmentInput): RiskAssessmentResult {
+    const timestamp = new Date().toLocaleString();
+    const lines = [
+      '🛡️ **AI Risk Assessment Results**',
+      `- **CVSS Score**: ${input.cvssScore}`,
+      `- **EPSS Score**: ${input.epssScore}`,
+      `- **CISA KEV**: ${input.cisaKevStatus}`,
+      `- **Exploits Known**: ${input.exploitsKnown}`,
+      `Generated ${timestamp}`,
+      '',
+      '📘 **Risk Assessment Analysis**',
+      `# ${input.vulnerabilityId} Technical Brief`,
+      `**Status**: ${input.patchInfo}`,
+      `**Priority**: ${input.businessPriority}`,
+      `**Confidence**: ${input.threatIntelConfidence}`
+    ];
+    return { text: lines.join('\n') };
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,3 +2,4 @@ export * from './ResearchAgent';
 export * from './RAGCuratorAgent';
 export * from './UserAssistantAgent';
 export * from './ValidationAgent';
+export * from './RiskAssessmentAgent';


### PR DESCRIPTION
## Summary
- implement RiskAssessmentAgent for formatted risk data
- expose new agent
- replace Package Managers patch tab with Vendor & Patch Info section showing advisories, patches, and timeline

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866ac48c924832cbc99fa47313fa92a