### PR TITLE
Add RiskAssessmentAgent and vendor patch tab

### DIFF
--- a/src/agents/RiskAssessmentAgent.test.ts
+++ b/src/agents/RiskAssessmentAgent.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { RiskAssessmentAgent, RiskAssessmentInput } from './RiskAssessmentAgent';
+
+describe('RiskAssessmentAgent', () => {
+  it('formats risk assessment output', () => {
+    const input: RiskAssessmentInput = {
+      cvssScore: 8.0,
+      epssScore: 0.75,
+      cisaKevStatus: 'YES',
+      exploitsKnown: 'YES',
+      vulnerabilityId: 'CVE-2017-1000251',
+      patchInfo: 'Patch Available, Released: 2017-09-30',
+      businessPriority: 'P2 – Next sprint priority for engineering',
+      threatIntelConfidence: 'High – Multiple authoritative sources: CERT, vendor, GitHub'
+    };
+
+    const result = RiskAssessmentAgent.generateAssessment(input);
+    expect(result.text).toContain('AI Risk Assessment Results');
+    expect(result.text).toContain('# CVE-2017-1000251 Technical Brief');
+    expect(result.text).toContain('Patch Available');
+  });
+});

--- a/src/agents/RiskAssessmentAgent.ts
+++ b/src/agents/RiskAssessmentAgent.ts
@@ -1,0 +1,35 @@
+export interface RiskAssessmentInput {
+  cvssScore: number;
+  epssScore: number;
+  cisaKevStatus: 'YES' | 'NO';
+  exploitsKnown: 'YES' | 'NO';
+  vulnerabilityId: string;
+  patchInfo: string;
+  businessPriority: string;
+  threatIntelConfidence: string;
+}
+
+export interface RiskAssessmentResult {
+  text: string;
+}
+
+export class RiskAssessmentAgent {
+  static generateAssessment(input: RiskAssessmentInput): RiskAssessmentResult {
+    const timestamp = new Date().toLocaleString();
+    const lines = [
+      '🛡️ **AI Risk Assessment Results**',
+      `- **CVSS Score**: ${input.cvssScore}`,
+      `- **EPSS Score**: ${input.epssScore}`,
+      `- **CISA KEV**: ${input.cisaKevStatus}`,
+      `- **Exploits Known**: ${input.exploitsKnown}`,
+      `Generated ${timestamp}`,
+      '',
+      '📘 **Risk Assessment Analysis**',
+      `# ${input.vulnerabilityId} Technical Brief`,
+      `**Status**: ${input.patchInfo}`,
+      `**Priority**: ${input.businessPriority}`,
+      `**Confidence**: ${input.threatIntelConfidence}`
+    ];
+    return { text: lines.join('\n') };
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,3 +2,4 @@ export * from './ResearchAgent';
 export * from './RAGCuratorAgent';
 export * from './UserAssistantAgent';
 export * from './ValidationAgent';
+export * from './RiskAssessmentAgent';

--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -5,7 +5,7 @@ import { utils } from '../utils/helpers';
 import { createStyles } from '../utils/styles';
 import { COLORS, CONSTANTS } from '../utils/constants';
 import CVSSDisplay from './CVSSDisplay';
-import { Brain, Database, Globe, Info, Loader2, Copy, RefreshCw, Package, CheckCircle, XCircle, AlertTriangle, Target, ChevronRight, FileText, ExternalLink, Search } from 'lucide-react';
+import { Brain, Database, Globe, Info, Loader2, Copy, RefreshCw, Package, CheckCircle, XCircle, AlertTriangle, Target, ChevronRight, FileText, ExternalLink, Search, Clock } from 'lucide-react';
 import TechnicalBrief from './TechnicalBrief';
 import ScoreChart from './ScoreChart';
 
@@ -61,8 +61,8 @@ const CVEDetailView = ({ vulnerability }) => {
   const safeAddNotification = addNotification || (() => {});
   const safeSetVulnerabilities = setVulnerabilities || (() => {});
 
-  // AI-Enhanced Patch Discovery System
-  const AIEnhancedPatchDiscovery = {
+  // Patch discovery helpers
+  const PatchDiscovery = {
     
     // Extract affected components from CVE description
     extractAffectedComponents: (description) => {
@@ -302,7 +302,7 @@ const CVEDetailView = ({ vulnerability }) => {
 
       // Add package-specific portals for known packages
       components.forEach(component => {
-        const packageSpecificPortal = AIEnhancedPatchDiscovery.getPackageSpecificPortal(component);
+        const packageSpecificPortal = PatchDiscovery.getPackageSpecificPortal(component);
         if (packageSpecificPortal && !portals.find(p => p.name === packageSpecificPortal.name)) {
           portals.push(packageSpecificPortal);
         }
@@ -422,7 +422,7 @@ const CVEDetailView = ({ vulnerability }) => {
             `"${component.name}" vulnerability fix`,
             `"${component.name}" security update`
           ],
-          sites: AIEnhancedPatchDiscovery.getComponentSites(component.ecosystem),
+          sites: PatchDiscovery.getComponentSites(component.ecosystem),
           priority: 'high'
         });
       });
@@ -657,14 +657,14 @@ const CVEDetailView = ({ vulnerability }) => {
 
       components.forEach(component => {
         // Generate package details based on component type
-        const packageInfo = AIEnhancedPatchDiscovery.getPackageInfo(component);
+        const packageInfo = PatchDiscovery.getPackageInfo(component);
         if (packageInfo) {
           overview.packages.push(packageInfo);
         }
       });
 
       // Extract vulnerability context
-      overview.vulnerabilityContext = AIEnhancedPatchDiscovery.extractVulnerabilityContext(vulnerability);
+      overview.vulnerabilityContext = PatchDiscovery.extractVulnerabilityContext(vulnerability);
 
       return overview;
     },
@@ -835,7 +835,7 @@ const CVEDetailView = ({ vulnerability }) => {
                                     url.includes('github');
             
             if (isSecurityRelated) {
-              const vendor = AIEnhancedPatchDiscovery.extractVendorFromUrl(url);
+              const vendor = PatchDiscovery.extractVendorFromUrl(url);
               const isPatchLike = url.includes('download') || 
                                 url.includes('maven') || 
                                 url.includes('npm') ||
@@ -906,7 +906,7 @@ const CVEDetailView = ({ vulnerability }) => {
       // Verify patches
       for (const patch of patches) {
         try {
-          const verification = await AIEnhancedPatchDiscovery.verifyUrl(patch.downloadUrl);
+          const verification = await PatchDiscovery.verifyUrl(patch.downloadUrl);
           patch.verified = verification.valid;
           patch.verificationStatus = verification.status;
           patch.lastChecked = new Date().toISOString();
@@ -922,7 +922,7 @@ const CVEDetailView = ({ vulnerability }) => {
       // Verify advisories
       for (const advisory of advisories) {
         try {
-          const verification = await AIEnhancedPatchDiscovery.verifyUrl(advisory.url);
+          const verification = await PatchDiscovery.verifyUrl(advisory.url);
           advisory.verified = verification.valid;
           advisory.verificationStatus = verification.status;
           advisory.lastChecked = new Date().toISOString();
@@ -978,8 +978,8 @@ const CVEDetailView = ({ vulnerability }) => {
     }
   };
 
-  // AI-Enhanced Patch Discovery Function
-  const discoverPatchesWithAI = async () => {
+  // Patch discovery function
+  const discoverPatches = async () => {
     if (!safeSettings.geminiApiKey) {
       safeAddNotification({
         type: 'error',
@@ -1002,7 +1002,7 @@ const CVEDetailView = ({ vulnerability }) => {
       const description = vulnerability.cve.description;
       
       // Extract affected components
-      const components = AIEnhancedPatchDiscovery.extractAffectedComponents(description);
+      const components = PatchDiscovery.extractAffectedComponents(description);
       
       // Generate AI search prompt
       const searchPrompt = `
@@ -1011,12 +1011,12 @@ You are a cybersecurity expert helping find official patches and fixes for vulne
 CVE ID: ${cveId}
 DESCRIPTION: ${description}
 
-TASK: Find official vendor patches, security advisories, and package manager updates for this CVE.
+TASK: Find official vendor patches, security advisories, and security bulletins for this CVE.
 
 SEARCH AND PROVIDE:
 1. **Official Vendor Downloads**: Direct download links for patched versions
 2. **Security Advisories**: Vendor security pages with detailed information
-3. **Package Manager Updates**: npm, Maven, pip, NuGet registry updates
+3. **Vendor Security Bulletins**: announcements and response timelines
 4. **GitHub Releases**: Official releases and security fixes
 5. **Distribution Updates**: Linux distribution security updates
 
@@ -1025,7 +1025,6 @@ IMPORTANT REQUIREMENTS:
 - Include specific version numbers that fix the vulnerability
 - Verify all information is current and accurate
 - Focus on official vendor sources
-- Include package manager dependency information
 
 RETURN FORMAT:
 For each fix found, provide:
@@ -1060,10 +1059,10 @@ Search comprehensively for all available patches and advisories.
       }
 
       // Parse AI response for patches and advisories
-      const { patches, advisories } = AIEnhancedPatchDiscovery.parseAIResponseForPatches(aiResponse.analysis);
+      const { patches, advisories } = PatchDiscovery.parseAIResponseForPatches(aiResponse.analysis);
       
       // Verify discovered URLs
-      const verified = await AIEnhancedPatchDiscovery.verifyPatchUrls(patches, advisories);
+      const verified = await PatchDiscovery.verifyPatchUrls(patches, advisories);
       
       // Generate comprehensive guidance
       const guidance = {
@@ -1071,11 +1070,11 @@ Search comprehensively for all available patches and advisories.
         components,
         aiPatches: verified.patches,
         aiAdvisories: verified.advisories,
-        vendorPortals: AIEnhancedPatchDiscovery.generateVendorPortals(components),
-        searchStrategies: AIEnhancedPatchDiscovery.generateSearchStrategies(cveId, components),
-        packageManagers: AIEnhancedPatchDiscovery.generatePackageManagerGuidance(components, cveId),
-        remediationSteps: AIEnhancedPatchDiscovery.generateRemediationSteps(cveId, components),
-        urgencyLevel: AIEnhancedPatchDiscovery.assessUrgencyLevel(vulnerability),
+        vendorPortals: PatchDiscovery.generateVendorPortals(components),
+        searchStrategies: PatchDiscovery.generateSearchStrategies(cveId, components),
+        packageManagers: PatchDiscovery.generatePackageManagerGuidance(components, cveId),
+        remediationSteps: PatchDiscovery.generateRemediationSteps(cveId, components),
+        urgencyLevel: PatchDiscovery.assessUrgencyLevel(vulnerability),
         aiAnalysis: aiResponse.analysis,
         generatedAt: new Date().toISOString(),
         searchPerformed: true,
@@ -1131,7 +1130,7 @@ Search comprehensively for all available patches and advisories.
       <div>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '24px' }}>
           <h2 style={{ fontSize: '1.5rem', fontWeight: '700', margin: 0 }}>
-            AI-Enhanced Patch Discovery
+            Patch Discovery
           </h2>
           
           <button
@@ -1141,7 +1140,7 @@ Search comprehensively for all available patches and advisories.
               padding: '12px 24px',
               opacity: fetchingPatches ? 0.7 : 1
             }}
-            onClick={discoverPatchesWithAI}
+            onClick={discoverPatches}
             disabled={fetchingPatches}
           >
             {fetchingPatches ? (
@@ -1153,7 +1152,7 @@ Search comprehensively for all available patches and advisories.
               <>
                 <Brain size={16} />
                 <Search size={14} style={{ marginLeft: '4px' }} />
-                Discover Patches with AI
+                Discover Patches
               </>
             )}
           </button>
@@ -1195,24 +1194,6 @@ Search comprehensively for all available patches and advisories.
 
               <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '12px', marginBottom: '16px' }}>
                 <div style={{ textAlign: 'center', padding: '12px', background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface, borderRadius: '8px' }}>
-                  <div style={{ fontSize: '1.5rem', fontWeight: '700', color: COLORS.green }}>
-                    {patchGuidance.aiPatches.length}
-                  </div>
-                  <div style={{ fontSize: '0.8rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                    AI Patches
-                  </div>
-                </div>
-
-                <div style={{ textAlign: 'center', padding: '12px', background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface, borderRadius: '8px' }}>
-                  <div style={{ fontSize: '1.5rem', fontWeight: '700', color: COLORS.blue }}>
-                    {patchGuidance.aiAdvisories.length}
-                  </div>
-                  <div style={{ fontSize: '0.8rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                    AI Advisories
-                  </div>
-                </div>
-
-                <div style={{ textAlign: 'center', padding: '12px', background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface, borderRadius: '8px' }}>
                   <div style={{ fontSize: '1.5rem', fontWeight: '700', color: COLORS.purple }}>
                     {patchGuidance.verifiedCount}
                   </div>
@@ -1222,7 +1203,7 @@ Search comprehensively for all available patches and advisories.
                 </div>
 
                 <div style={{ textAlign: 'center', padding: '12px', background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface, borderRadius: '8px' }}>
-                  <div style={{ fontSize: '1.5rem', fontWeight: '700', color: COLORS.yellow }}>
+                  <div style={{ fontSize: '1.5rem', fontWeight: '700', color: COLORS.purple }}>
                     {patchGuidance.components.length}
                   </div>
                   <div style={{ fontSize: '0.8rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
@@ -1242,9 +1223,8 @@ Search comprehensively for all available patches and advisories.
             }}>
               {[
                 { key: 'overview', label: 'Overview', icon: Info },
-                { key: 'ai-patches', label: 'AI Patches', icon: Package },
                 { key: 'vendors', label: 'Vendor Portals', icon: Globe },
-                { key: 'packages', label: 'Package Managers', icon: Database },
+                { key: 'packages', label: 'Vendor & Patch Info', icon: Database },
                 { key: 'remediation', label: 'Remediation', icon: Target }
               ].map(({ key, label, icon: Icon }) => (
                 <button
@@ -1277,7 +1257,7 @@ Search comprehensively for all available patches and advisories.
                   
                   {/* Package Details */}
                   {patchGuidance.components.map((component, index) => {
-                    const packageInfo = AIEnhancedPatchDiscovery.getPackageInfo(component);
+                    const packageInfo = PatchDiscovery.getPackageInfo(component);
                     return (
                       <div key={index} style={{
                         ...styles.card,
@@ -1398,192 +1378,6 @@ Search comprehensively for all available patches and advisories.
                 </div>
               )}
 
-              {activeGuidanceSection === 'ai-patches' && (
-                <div>
-                  <h3 style={{ marginBottom: '16px' }}>AI-Discovered Patches & Advisories</h3>
-                  
-                  {/* AI Patches */}
-                  {patchGuidance.aiPatches.length > 0 && (
-                    <div style={{ marginBottom: '32px' }}>
-                      <h4 style={{ marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                        <Package size={18} color={COLORS.green} />
-                        Direct Patches ({patchGuidance.aiPatches.length})
-                      </h4>
-                      
-                      {patchGuidance.aiPatches.map((patch, index) => (
-                        <div key={index} style={{
-                          ...styles.card,
-                          marginBottom: '16px',
-                          borderLeft: `4px solid ${patch.verified ? COLORS.green : COLORS.yellow}`
-                        }}>
-                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px' }}>
-                            <div style={{ flex: 1 }}>
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
-                                <h5 style={{ margin: 0, fontSize: '1rem', fontWeight: '600' }}>
-                                  {patch.vendor} Patch
-                                </h5>
-                                <span style={{
-                                  padding: '2px 6px',
-                                  borderRadius: '4px',
-                                  fontSize: '0.7rem',
-                                  fontWeight: '600',
-                                  background: patch.verified ? `${COLORS.green}20` : `${COLORS.yellow}20`,
-                                  color: patch.verified ? COLORS.green : COLORS.yellow
-                                }}>
-                                  {patch.verified ? 'VERIFIED' : 'UNVERIFIED'}
-                                </span>
-                                <span style={{
-                                  padding: '2px 6px',
-                                  borderRadius: '4px',
-                                  fontSize: '0.7rem',
-                                  fontWeight: '600',
-                                  background: `${COLORS.purple}20`,
-                                  color: COLORS.purple
-                                }}>
-                                  AI DISCOVERED
-                                </span>
-                              </div>
-                              
-                              <p style={{ margin: '0 0 8px 0', fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                                {patch.description}
-                              </p>
-                              
-                              <div style={{
-                                padding: '8px 12px',
-                                background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface,
-                                borderRadius: '6px',
-                                fontSize: '0.8rem',
-                                fontFamily: 'monospace'
-                              }}>
-                                <strong>URL:</strong> {patch.downloadUrl}
-                              </div>
-                            </div>
-                            
-                            <a
-                              href={patch.downloadUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              style={{
-                                ...styles.button,
-                                ...styles.buttonPrimary,
-                                padding: '8px 16px',
-                                fontSize: '0.85rem',
-                                textDecoration: 'none',
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '6px'
-                              }}
-                            >
-                              <Package size={14} />
-                              Download
-                            </a>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* AI Advisories */}
-                  {patchGuidance.aiAdvisories.length > 0 && (
-                    <div style={{ marginBottom: '32px' }}>
-                      <h4 style={{ marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                        <FileText size={18} color={COLORS.blue} />
-                        Security Advisories ({patchGuidance.aiAdvisories.length})
-                      </h4>
-                      
-                      {patchGuidance.aiAdvisories.map((advisory, index) => (
-                        <div key={index} style={{
-                          ...styles.card,
-                          marginBottom: '16px',
-                          borderLeft: `4px solid ${advisory.verified ? COLORS.green : COLORS.yellow}`
-                        }}>
-                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px' }}>
-                            <div style={{ flex: 1 }}>
-                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
-                                <h5 style={{ margin: 0, fontSize: '1rem', fontWeight: '600' }}>
-                                  {advisory.title}
-                                </h5>
-                                <span style={{
-                                  padding: '2px 6px',
-                                  borderRadius: '4px',
-                                  fontSize: '0.7rem',
-                                  fontWeight: '600',
-                                  background: advisory.verified ? `${COLORS.green}20` : `${COLORS.yellow}20`,
-                                  color: advisory.verified ? COLORS.green : COLORS.yellow
-                                }}>
-                                  {advisory.verified ? 'VERIFIED' : 'UNVERIFIED'}
-                                </span>
-                                <span style={{
-                                  padding: '2px 6px',
-                                  borderRadius: '4px',
-                                  fontSize: '0.7rem',
-                                  fontWeight: '600',
-                                  background: `${COLORS.purple}20`,
-                                  color: COLORS.purple
-                                }}>
-                                  AI DISCOVERED
-                                </span>
-                              </div>
-                              
-                              <p style={{ margin: '0 0 8px 0', fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                                {advisory.summary}
-                              </p>
-                              
-                              <div style={{
-                                padding: '8px 12px',
-                                background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface,
-                                borderRadius: '6px',
-                                fontSize: '0.8rem',
-                                fontFamily: 'monospace'
-                              }}>
-                                <strong>URL:</strong> {advisory.url}
-                              </div>
-                            </div>
-                            
-                            <a
-                              href={advisory.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              style={{
-                                ...styles.button,
-                                ...styles.buttonPrimary,
-                                padding: '8px 16px',
-                                fontSize: '0.85rem',
-                                textDecoration: 'none',
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: '6px'
-                              }}
-                            >
-                              <ExternalLink size={14} />
-                              View Advisory
-                            </a>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* No AI results */}
-                  {patchGuidance.aiPatches.length === 0 && patchGuidance.aiAdvisories.length === 0 && (
-                    <div style={{
-                      textAlign: 'center',
-                      padding: '48px 32px',
-                      background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface,
-                      borderRadius: '8px'
-                    }}>
-                      <AlertTriangle size={48} color={COLORS.yellow} style={{ marginBottom: '16px', opacity: 0.7 }} />
-                      <h4 style={{ margin: '0 0 12px 0', fontSize: '1.1rem', fontWeight: '600' }}>
-                        No Direct Patches Found
-                      </h4>
-                      <p style={{ fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                        AI search completed but no specific patches or advisories were discovered. 
-                        Check the other tabs for comprehensive guidance on finding patches manually.
-                      </p>
-                    </div>
-                  )}
-                </div>
-              )}
 
               {activeGuidanceSection === 'vendors' && (
                 <div>
@@ -1740,60 +1534,169 @@ Search comprehensively for all available patches and advisories.
 
               {activeGuidanceSection === 'packages' && (
                 <div>
-                  <h3 style={{ marginBottom: '16px' }}>Package Manager Updates</h3>
-                  <div style={{ display: 'grid', gap: '16px' }}>
-                    {patchGuidance.packageManagers.map((pm, index) => (
-                      <div key={index} style={{
-                        ...styles.card,
-                        borderLeft: `4px solid ${COLORS.green}`
-                      }}>
-                        <h4 style={{ margin: '0 0 8px 0' }}>{pm.name}</h4>
-                        <p style={{ margin: '0 0 16px 0', fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                          Component: {pm.component}
-                        </p>
-                        
-                        <div style={{ marginBottom: '16px' }}>
-                          <strong style={{ fontSize: '0.9rem' }}>Check Commands:</strong>
-                          <div style={{ marginTop: '8px' }}>
-                            {pm.checkCommands.map((cmd, cIndex) => (
-                              <code key={cIndex} style={{
-                                display: 'block',
+                  <h3 style={{ marginBottom: '16px' }}>Vendor &amp; Patch Information</h3>
+
+                  {/* Vendor Response Timeline */}
+                  {(patchGuidance.aiPatches.length > 0 || patchGuidance.aiAdvisories.length > 0) && (
+                    <div style={{ marginBottom: '24px' }}>
+                      <h4 style={{ marginBottom: '12px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <Clock size={18} color={COLORS.blue} />
+                        Vendor Response Timeline
+                      </h4>
+                      <ul style={{ listStyle: 'none', padding: 0 }}>
+                        {[...patchGuidance.aiPatches, ...patchGuidance.aiAdvisories]
+                          .filter(item => item.releaseDate || item.publishDate)
+                          .sort((a, b) => new Date(a.releaseDate || a.publishDate).getTime() - new Date(b.releaseDate || b.publishDate).getTime())
+                          .map((item, index) => (
+                            <li key={index} style={{ marginBottom: '8px', fontSize: '0.9rem' }}>
+                              <strong>{new Date(item.releaseDate || item.publishDate).toLocaleDateString()}</strong>
+                              {` – ${item.vendor || item.source}`}
+                              {item.patchVersion ? ` ${item.patchVersion}` : ''}
+                            </li>
+                          ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  {/* Official Advisories */}
+                  {patchGuidance.aiAdvisories.length > 0 && (
+                    <div style={{ marginBottom: '32px' }}>
+                      <h4 style={{ marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <FileText size={18} color={COLORS.blue} />
+                        Official Vendor Advisories ({patchGuidance.aiAdvisories.length})
+                      </h4>
+                      {patchGuidance.aiAdvisories.map((advisory, index) => (
+                        <div key={index} style={{
+                          ...styles.card,
+                          marginBottom: '16px',
+                          borderLeft: `4px solid ${advisory.verified ? COLORS.green : COLORS.yellow}`
+                        }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px' }}>
+                            <div style={{ flex: 1 }}>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+                                <h5 style={{ margin: 0, fontSize: '1rem', fontWeight: '600' }}>
+                                  {advisory.title}
+                                </h5>
+                                <span style={{
+                                  padding: '2px 6px',
+                                  borderRadius: '4px',
+                                  fontSize: '0.7rem',
+                                  fontWeight: '600',
+                                  background: advisory.verified ? `${COLORS.green}20` : `${COLORS.yellow}20`,
+                                  color: advisory.verified ? COLORS.green : COLORS.yellow
+                                }}>
+                                  {advisory.verified ? 'VERIFIED' : 'UNVERIFIED'}
+                                </span>
+                              </div>
+
+                              <p style={{ margin: '0 0 8px 0', fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
+                                {advisory.summary}
+                              </p>
+
+                              <div style={{
                                 padding: '8px 12px',
                                 background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface,
-                                borderRadius: '4px',
+                                borderRadius: '6px',
                                 fontSize: '0.8rem',
-                                marginBottom: '4px'
+                                fontFamily: 'monospace'
                               }}>
-                                {cmd}
-                              </code>
-                            ))}
+                                <strong>URL:</strong> {advisory.url}
+                              </div>
+                            </div>
+
+                            <a
+                              href={advisory.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              style={{
+                                ...styles.button,
+                                ...styles.buttonPrimary,
+                                padding: '8px 16px',
+                                fontSize: '0.85rem',
+                                textDecoration: 'none',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '6px'
+                              }}
+                            >
+                              <ExternalLink size={14} />
+                              View Advisory
+                            </a>
                           </div>
                         </div>
-                        
-                        <div style={{ marginBottom: '16px' }}>
-                          <strong style={{ fontSize: '0.9rem' }}>Update Commands:</strong>
-                          <div style={{ marginTop: '8px' }}>
-                            {pm.updateCommands.map((cmd, uIndex) => (
-                              <code key={uIndex} style={{
-                                display: 'block',
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Patch Downloads */}
+                  {patchGuidance.aiPatches.length > 0 && (
+                    <div style={{ marginBottom: '32px' }}>
+                      <h4 style={{ marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        <Package size={18} color={COLORS.green} />
+                        Patch Downloads &amp; Links ({patchGuidance.aiPatches.length})
+                      </h4>
+                      {patchGuidance.aiPatches.map((patch, index) => (
+                        <div key={index} style={{
+                          ...styles.card,
+                          marginBottom: '16px',
+                          borderLeft: `4px solid ${patch.verified ? COLORS.green : COLORS.yellow}`
+                        }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '16px' }}>
+                            <div style={{ flex: 1 }}>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+                                <h5 style={{ margin: 0, fontSize: '1rem', fontWeight: '600' }}>
+                                  {patch.vendor} Patch
+                                </h5>
+                                <span style={{
+                                  padding: '2px 6px',
+                                  borderRadius: '4px',
+                                  fontSize: '0.7rem',
+                                  fontWeight: '600',
+                                  background: patch.verified ? `${COLORS.green}20` : `${COLORS.yellow}20`,
+                                  color: patch.verified ? COLORS.green : COLORS.yellow
+                                }}>
+                                  {patch.verified ? 'VERIFIED' : 'UNVERIFIED'}
+                                </span>
+                              </div>
+
+                              <p style={{ margin: '0 0 8px 0', fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
+                                {patch.description}
+                              </p>
+
+                              <div style={{
                                 padding: '8px 12px',
                                 background: safeSettings.darkMode ? COLORS.dark.surface : COLORS.light.surface,
-                                borderRadius: '4px',
+                                borderRadius: '6px',
                                 fontSize: '0.8rem',
-                                marginBottom: '4px'
+                                fontFamily: 'monospace'
                               }}>
-                                {cmd}
-                              </code>
-                            ))}
+                                <strong>URL:</strong> {patch.downloadUrl}
+                              </div>
+                            </div>
+
+                            <a
+                              href={patch.downloadUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              style={{
+                                ...styles.button,
+                                ...styles.buttonPrimary,
+                                padding: '8px 16px',
+                                fontSize: '0.85rem',
+                                textDecoration: 'none',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '6px'
+                              }}
+                            >
+                              <Package size={14} />
+                              Download
+                            </a>
                           </div>
                         </div>
-                        
-                        <div style={{ fontSize: '0.8rem', color: safeSettings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
-                          <strong>Registry:</strong> <a href={pm.registryUrl} target="_blank" rel="noopener noreferrer">{pm.registryUrl}</a>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -1860,17 +1763,17 @@ Search comprehensively for all available patches and advisories.
           }}>
             <Brain size={48} style={{ marginBottom: '16px', opacity: 0.5, color: safeSettings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }} />
             <h4 style={{ margin: '0 0 12px 0', fontSize: '1.1rem', fontWeight: '600' }}>
-              AI-Enhanced Patch Discovery
+              Patch Discovery
             </h4>
             <p style={{ margin: '0 0 20px 0', fontSize: '0.9rem', color: safeSettings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-              Click "Discover Patches with AI" to use AI with Google Search to find official patches, security advisories, and vendor-specific updates.
+              Click "Discover Patches" to search for official patches, security advisories, and vendor updates.
             </p>
             <div style={{ fontSize: '0.85rem', color: safeSettings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText }}>
               <strong>AI will:</strong>
               <ul style={{ textAlign: 'left', maxWidth: '400px', margin: '8px auto 0 auto', paddingLeft: '20px' }}>
                 <li>Search for official vendor patches and downloads</li>
                 <li>Find security advisories and vulnerability pages</li>
-                <li>Discover package manager updates (npm, Maven, pip)</li>
+                <li>Summarize vendor security bulletins and timelines</li>
                 <li>Verify discovered URLs for accessibility</li>
                 <li>Provide comprehensive remediation guidance</li>
               </ul>
@@ -2520,22 +2423,6 @@ Focus on actionable information for security professionals.
               {vulnerability?.epss && (
                 <span style={{ color: vulnerability.epss.epssFloat > CONSTANTS.EPSS_THRESHOLDS.HIGH ? COLORS.red : vulnerability.epss.epssFloat > CONSTANTS.EPSS_THRESHOLDS.MEDIUM ? COLORS.yellow : COLORS.green }}>
                   {vulnerability.epss.epssFloat > CONSTANTS.EPSS_THRESHOLDS.HIGH ? ' (High Risk)' : vulnerability.epss.epssFloat > CONSTANTS.EPSS_THRESHOLDS.MEDIUM ? ' (Medium Risk)' : ' (Low Risk)'}
-                </span>
-              )}
-            </p>
-            <p style={{ margin: '0 0 8px 0' }}>
-              <strong>AI Patches:</strong> {patchGuidance?.aiPatches?.length || 0}
-              {patchGuidance?.aiPatches?.length > 0 && (
-                <span style={{ color: COLORS.green, marginLeft: '4px' }}>
-                  (AI Discovered)
-                </span>
-              )}
-            </p>
-            <p style={{ margin: '0 0 8px 0' }}>
-              <strong>AI Advisories:</strong> {patchGuidance?.aiAdvisories?.length || 0}
-              {patchGuidance?.aiAdvisories?.length > 0 && (
-                <span style={{ color: COLORS.blue, marginLeft: '4px' }}>
-                  (AI Verified)
                 </span>
               )}
             </p>

--- a/src/services/UtilityService.ts
+++ b/src/services/UtilityService.ts
@@ -666,8 +666,8 @@ export function generateUserWarning(confidence: string, validation: any): string
 export function createAIDataDisclaimer(vulnerability: any): string {
   const aiGeneratedCount = countAIGeneratedFindings(vulnerability);
   const verifiedCount = countVerifiedFindings(vulnerability.validation || {});
-  
-  return `📊 Analysis Summary: ${aiGeneratedCount} AI-generated findings, ${verifiedCount} verified. Please review all findings before taking action.`;
+
+  return `📊 Analysis Summary: ${aiGeneratedCount} AI-generated findings, ${verifiedCount} verified. AI is prone to mistakes, so validate the evidence before taking action.`;
 }
 
 // Count AI Generated Findings


### PR DESCRIPTION
## Summary
- implement RiskAssessmentAgent for formatted risk data
- expose new agent
- replace Package Managers patch tab with Vendor & Patch Info section showing advisories, patches, and timeline
- remove AI patches tab and rename patch discovery wording
- add reliability disclaimer that AI is prone to mistakes and evidence should be validated

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ac48c924832cbc99fa47313fa92a