### PR TITLE
Enable remediation plan responses

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,21 +256,23 @@ const App = () => {
           {showChat ? <X size={32} /> : <MessageSquare size={32} />}
         </button>
 
-        {/* Conditionally Render ChatInterface */}
+        {/* Conditionally Render ChatInterface as a side panel */}
         {showChat && (
-          <div style={{ // This outer div is the modal container for ChatInterface
-            position: 'fixed',
-            bottom: '112px', // Above the toggle button
-            right: '32px',
-            width: '400px', // Adjust as needed
-            height: '60vh', // Adjust as needed
-            maxHeight: '700px',
-            zIndex: 999, // Below the toggle button if it needs to overlap, or manage carefully
-            boxShadow: `0 8px 24px rgba(${utils.hexToRgb(COLORS.dark.shadow)}, 0.3)`, // Consistent shadow
-            borderRadius: '12px', // Consistent with cards
-            overflow: 'hidden', // To ensure ChatInterface respects border radius
-            // Background will be handled by ChatInterface itself via styles.card.background
-          }}>
+          <div
+            style={{
+              position: 'fixed',
+              top: 0,
+              right: 0,
+              height: '100vh',
+              width: '420px',
+              maxWidth: '100%',
+              zIndex: 999, // Below the toggle button so it's still clickable
+              boxShadow: `0 0 24px rgba(${utils.hexToRgb(COLORS.dark.shadow)}, 0.3)`,
+              borderLeft: `1px solid ${settings.darkMode ? COLORS.dark.border : COLORS.light.border}`,
+              overflow: 'hidden',
+              background: styles.card.background,
+            }}
+          >
             <ChatInterface initialCveId={vulnerabilities[0]?.cve?.id || null} />
           </div>
         )}

--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -25,4 +25,12 @@ describe('UserAssistantAgent validation integration', () => {
     expect(validateSpy).toHaveBeenCalled();
     expect(res.data).toEqual(mockValidation);
   });
+
+  it('returns remediation plan when asked', async () => {
+    const agent = new UserAssistantAgent({});
+    const res = await agent.handleQuery('remediation plan for CVE-1234-0001');
+    expect(res.text).toContain('Remediation Plan');
+    expect(Array.isArray(res.data)).toBe(true);
+    expect(res.data.length).toBeGreaterThan(0);
+  });
 });

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -212,6 +212,16 @@ export interface PatchData {
   summary?: string; // Overall summary of patch availability
 }
 
+export interface RemediationStep {
+  phase: string;
+  title: string;
+  description: string;
+  actions: string[];
+  tools: string[];
+  estimatedTime: string;
+  priority: string;
+}
+
 export interface TechnicalAnalysisData {
   text?: string; // In-depth technical explanation of the vulnerability
   attackVector?: string; // How the vulnerability is exploited

--- a/src/utils/remediation.ts
+++ b/src/utils/remediation.ts
@@ -1,0 +1,84 @@
+export interface RemediationStep {
+  phase: string;
+  title: string;
+  description: string;
+  actions: string[];
+  tools: string[];
+  estimatedTime: string;
+  priority: string;
+}
+
+export function generateRemediationPlan(): RemediationStep[] {
+  return [
+    {
+      phase: 'Assessment',
+      title: 'Identify Affected Systems',
+      description: 'Determine which systems in your environment are affected by this vulnerability',
+      actions: [
+        'Inventory all systems running the affected software',
+        'Identify current versions of affected components',
+        'Determine system criticality and exposure level',
+        'Check if systems are internet-facing or internal'
+      ],
+      tools: ['Asset management tools', 'Network scanners', 'Configuration management'],
+      estimatedTime: '1-4 hours',
+      priority: 'critical'
+    },
+    {
+      phase: 'Research',
+      title: 'Find and Validate Patches',
+      description: 'Research available patches and security updates',
+      actions: [
+        'Search vendor security advisories for patches',
+        'Check package repositories for updated versions',
+        'Review patch release notes and compatibility',
+        'Verify patch authenticity and integrity'
+      ],
+      tools: ['Vendor security portals', 'Package managers', 'Security databases'],
+      estimatedTime: '2-6 hours',
+      priority: 'high'
+    },
+    {
+      phase: 'Testing',
+      title: 'Test Patches in Safe Environment',
+      description: 'Validate patches in non-production environment',
+      actions: [
+        'Set up test environment matching production',
+        'Apply patches to test systems',
+        'Verify application functionality after patching',
+        'Test rollback procedures if needed'
+      ],
+      tools: ['Test environments', 'Monitoring tools', 'Functional tests'],
+      estimatedTime: '4-12 hours',
+      priority: 'high'
+    },
+    {
+      phase: 'Deployment',
+      title: 'Deploy Patches to Production',
+      description: 'Systematically apply patches to production systems',
+      actions: [
+        'Schedule maintenance windows',
+        'Create system backups before patching',
+        'Apply patches in staged deployment',
+        'Monitor systems during deployment'
+      ],
+      tools: ['Deployment tools', 'Backup systems', 'Monitoring dashboards'],
+      estimatedTime: '2-8 hours per system group',
+      priority: 'critical'
+    },
+    {
+      phase: 'Verification',
+      title: 'Verify Patch Effectiveness',
+      description: 'Confirm that patches have been successfully applied',
+      actions: [
+        'Scan systems to verify vulnerability is closed',
+        'Test application functionality post-patch',
+        'Monitor system performance and stability',
+        'Update vulnerability management records'
+      ],
+      tools: ['Vulnerability scanners', 'Application monitors', 'SIEM systems'],
+      estimatedTime: '1-3 hours',
+      priority: 'medium'
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- add remediation plan generation utils
- expose `RemediationStep` type
- update UserAssistantAgent with remediation plan intent & handler
- open chat assistant in a side panel
- test remediation plan handling

## Testing
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866be17831c832c8d4f3c5a047e2f5a