### PR TITLE
Add help command and patch summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,13 @@ npm start
 3. Get 3000+ word comprehensive security assessment
 ```
 
+### **🗣️ Smart Assistant Commands**
+```
+/help             - List available assistant commands
+/bulk_summary     - Summarize results from your uploaded CVE file (includes patch search counts)
+/component_summary - Show impacted components across bulk CVEs
+```
+
 ### **📈 Executive Reporting**
 ```
 1. Generate vulnerability analysis

--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -64,4 +64,29 @@ describe('UserAssistantAgent validation integration', () => {
     expect(res.text).toContain('Apache HTTP Server');
     expect(res.text).toContain('CVE-0001, CVE-0002');
   });
+
+  it('returns help information for /help command', async () => {
+    const agent = new UserAssistantAgent({});
+    const res = await agent.handleQuery('/help');
+    expect(res.text).toContain('Available commands');
+    expect(res.sender).toBe('system');
+  });
+
+  it('includes patch summary in bulk summary', async () => {
+    const agent = new UserAssistantAgent({});
+    agent.setBulkAnalysisResults([
+      {
+        cveId: 'CVE-0003',
+        status: 'Complete',
+        data: {
+          patchSearchSummary: { patchesFound: 1, advisoriesFound: 0 }
+        } as any
+      }
+    ]);
+
+    const res = await agent.handleQuery('/bulk_summary');
+    expect(res.text).toContain('Patch Search Summary');
+    expect(res.text).toContain('CVE-0003');
+    expect(res.text).toContain('1 patches');
+  });
 });

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -59,6 +59,9 @@ export class UserAssistantAgent {
     if (lowerQuery === '/component_summary') {
       return this.generateBulkComponentImpactSummary();
     }
+    if (lowerQuery === '/help') {
+      return this.generateHelpMessage();
+    }
 
     // Determine operational CVE ID
     if (cveMatch) {
@@ -647,6 +650,15 @@ export class UserAssistantAgent {
       summaryText += `No CVEs found in CISA KEV or with CVSS score >= 9.0 among the successfully analyzed items.\n\n`;
     }
 
+    // Patch/advisory search summary per CVE
+    summaryText += `**Patch Search Summary:**\n`;
+    this.bulkAnalysisResults.forEach(result => {
+      const patches = result.data?.patchSearchSummary?.patchesFound;
+      const advisories = result.data?.patchSearchSummary?.advisoriesFound;
+      summaryText += `- ${result.cveId}: ${patches ?? 'undefined'} patches, ${advisories ?? 'undefined'} advisories from searched vendors\n`;
+    });
+    summaryText += `\n`;
+
     summaryText += "You can ask for details on any specific CVE by typing its ID (e.g., 'CVE-2023-1234').";
 
     return {
@@ -693,5 +705,14 @@ export class UserAssistantAgent {
     });
 
     return { text: summaryText, sender: 'bot', id: Date.now().toString() };
+  }
+
+  public generateHelpMessage(): ChatResponse {
+    const helpText = `Available commands:\n` +
+      `- /help: Show this help message\n` +
+      `- /bulk_summary: Summarize uploaded CVE analysis results\n` +
+      `- /component_summary: Summarize affected components across uploaded CVEs\n` +
+      `\nYou can also ask about a specific CVE, e.g. 'Tell me about CVE-2023-1234'.`;
+    return { text: helpText, sender: 'system', id: Date.now().toString() };
   }
 }


### PR DESCRIPTION
## Summary
- provide `/help` command with instructions in UserAssistantAgent
- include patch/advisory search counts in bulk summary
- document assistant commands in README
- test help command and bulk patch summary

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68679f18f49c832c8c77bb9673a5b2b2