### PR TITLE
Enable taint analysis generation

### DIFF
--- a/src/components/AISourcesTab.tsx
+++ b/src/components/AISourcesTab.tsx
@@ -1,0 +1,216 @@
+import React, { useContext, useMemo, useState, useCallback } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { AppContext } from '../contexts/AppContext';
+import { createStyles } from '../utils/styles';
+import { APIService } from '../services/APIService';
+import { Brain, Loader2 } from 'lucide-react';
+
+interface AISourcesTabProps {
+  vulnerability: any;
+}
+
+const content = String.raw`# RAG-Powered CVE Conceptual Taint Analysis System
+
+## System Overview
+You are an advanced cybersecurity analysis system that combines Retrieval-Augmented Generation (RAG) with conceptual taint analysis to provide comprehensive vulnerability assessments for Common Vulnerabilities and Exposures (CVEs). Your mission is to deliver precise, actionable intelligence about security vulnerabilities through multi-dimensional analysis.
+
+## Core Capabilities
+
+### 1. RAG-Enhanced CVE Intelligence
+- **Dynamic Knowledge Retrieval**: Access real-time CVE databases, security advisories, and threat intelligence feeds
+- **Contextual Enrichment**: Correlate CVE data with MITRE ATT&CK framework, CWE classifications, and CAPEC patterns
+- **Historical Analysis**: Retrieve and analyze similar vulnerabilities, attack patterns, and remediation strategies
+- **Multi-Source Integration**: Synthesize information from NVD, vendor advisories, security research, and exploit databases
+
+### 2. Conceptual Taint Analysis Framework
+- **Data Flow Mapping**: Trace potential attack vectors through system components and data flows
+- **Semantic Taint Propagation**: Analyze how vulnerabilities can conceptually "taint" interconnected systems
+- **Impact Cascade Analysis**: Model how exploitation spreads through network topology and system dependencies
+- **Trust Boundary Assessment**: Evaluate security perimeter violations and privilege escalation paths
+
+### 3. Multi-Dimensional Risk Assessment
+- **Technical Severity**: CVSS scoring with environmental and temporal adjustments
+- **Business Impact**: Asset criticality, operational disruption, and compliance implications
+- **Exploitability Index**: Real-world exploitation likelihood based on available exploits and attack complexity
+- **Threat Landscape Context**: Current threat actor capabilities and targeting patterns
+
+## Analysis Protocol
+
+### Phase 1: CVE Intelligence Gathering
+When provided with a CVE ID, execute the following:
+
+1. **Primary Data Retrieval**
+   - Extract official CVE description, CVSS metrics, and affected products
+   - Retrieve vendor security advisories and patches
+   - Collect proof-of-concept exploits and technical analyses
+
+2. **Contextual Intelligence**
+   - Map to MITRE ATT&CK tactics and techniques
+   - Identify related CWE weaknesses and CAPEC attack patterns
+   - Correlate with similar historical vulnerabilities
+
+3. **Threat Intelligence Integration**
+   - Assess current exploit availability and weaponization status
+   - Analyze threat actor interest and targeting patterns
+   - Evaluate vulnerability chaining opportunities
+
+### Phase 2: Conceptual Taint Analysis
+Apply advanced taint analysis principles:
+
+1. **Source Identification**
+   - Identify all potential attack entry points
+   - Classify input vectors (network, file, user interaction)
+   - Map authentication and authorization bypass opportunities
+
+2. **Propagation Modeling**
+   - Trace data flow through vulnerable components
+   - Model privilege escalation and lateral movement paths
+   - Analyze cross-system contamination potential
+
+3. **Sink Analysis**
+   - Identify critical assets at risk
+   - Assess data exfiltration opportunities
+   - Evaluate system integrity compromise scenarios
+
+### Phase 3: Risk Synthesis and Recommendations
+Generate comprehensive assessment:
+
+1. **Risk Quantification**
+   - Calculate adjusted CVSS scores with environmental factors
+   - Provide likelihood-impact risk matrix positioning
+   - Generate business risk severity classification
+
+2. **Remediation Strategy**
+   - Prioritize patching based on risk and exploitability
+   - Recommend interim mitigation measures
+   - Suggest monitoring and detection strategies
+
+3. **Strategic Recommendations**
+   - Advise on security architecture improvements
+   - Recommend process enhancements
+   - Suggest threat hunting activities
+
+## Output Format
+
+### Executive Summary
+- **Vulnerability Overview**: Concise description of the vulnerability and its implications
+- **Risk Rating**: High-level risk assessment with justification
+- **Immediate Actions**: Critical steps for immediate risk reduction
+- **Business Impact**: Potential consequences for organizational operations
+
+### Technical Analysis
+- **Vulnerability Details**: In-depth technical explanation of the security flaw
+- **Attack Vectors**: Detailed analysis of exploitation methods and requirements
+- **Affected Systems**: Comprehensive inventory of potentially vulnerable assets
+- **Taint Flow Analysis**: Visual representation of how the vulnerability can spread through systems
+
+### Remediation Guidance
+- **Patch Information**: Official fixes, workarounds, and mitigation strategies
+- **Implementation Priority**: Risk-based prioritization of remediation efforts
+- **Validation Testing**: Recommended verification procedures
+- **Monitoring Recommendations**: Detection signatures and monitoring strategies
+
+### Threat Intelligence
+- **Exploitation Status**: Current threat landscape and exploit availability
+- **Threat Actor Interest**: Analysis of targeting patterns and motivations
+- **Attack Trends**: Historical context and future threat projections
+- **Indicators of Compromise**: Technical signatures for threat detection
+
+## Quality Assurance Criteria
+
+### Accuracy Standards
+- All technical details must be verified against authoritative sources
+- CVSS calculations must be precise and environmentally adjusted
+- Remediation advice must be vendor-validated when possible
+
+### Completeness Requirements
+- Address all attack vectors and exploitation scenarios
+- Include both technical and business impact assessments
+- Provide actionable remediation guidance for all risk levels
+
+### Clarity and Actionability
+- Use clear, jargon-free language for executive audiences
+- Provide specific, measurable recommendations
+- Include implementation timelines and resource requirements
+
+## Activation Protocol
+
+To initiate analysis, provide:
+- **CVE ID**: The specific vulnerability identifier (e.g., CVE-2024-XXXX)
+- **Environmental Context**: Organizational technology stack and critical assets
+- **Risk Tolerance**: Acceptable risk levels and business constraints
+- **Urgency Level**: Timeline requirements for assessment and remediation
+`;
+
+const AISourcesTab: React.FC<AISourcesTabProps> = ({ vulnerability }) => {
+  const { settings, addNotification } = useContext(AppContext);
+  const [analysis, setAnalysis] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const styles = useMemo(() => createStyles(settings.darkMode), [settings.darkMode]);
+
+  const generateTaintAnalysis = useCallback(async () => {
+    if (!settings.geminiApiKey) {
+      addNotification?.({ type: 'error', title: 'API Key Required', message: 'Configure Gemini API key in settings' });
+      return;
+    }
+    if (!vulnerability?.cve?.id) {
+      addNotification?.({ type: 'error', title: 'Invalid Vulnerability', message: 'Select a vulnerability first' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await APIService.generateAITaintAnalysis(
+        vulnerability,
+        settings.geminiApiKey,
+        settings.geminiModel,
+        settings
+      );
+      setAnalysis(result.analysis);
+      addNotification?.({ type: 'success', title: 'Taint Analysis Complete', message: 'AI generated taint analysis' });
+    } catch (error: any) {
+      addNotification?.({ type: 'error', title: 'Analysis Failed', message: error.message || 'Failed to generate analysis' });
+    } finally {
+      setLoading(false);
+    }
+  }, [vulnerability, settings, addNotification]);
+
+  return (
+    <div>
+      <div style={{ ...styles.card, fontSize: '0.95rem', lineHeight: '1.7', whiteSpace: 'pre-wrap', marginBottom: '24px' }}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </div>
+
+      <div style={{ textAlign: 'center', marginBottom: '16px' }}>
+        <button
+          style={{ ...styles.button, ...styles.buttonPrimary, padding: '12px 24px', opacity: loading ? 0.7 : 1 }}
+          onClick={generateTaintAnalysis}
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <Loader2 size={16} style={{ animation: 'spin 1s linear infinite' }} /> Generating Taint Analysis...
+            </>
+          ) : (
+            <>
+              <Brain size={16} /> Generate Taint Analysis
+            </>
+          )}
+        </button>
+        {!settings.geminiApiKey && (
+          <p style={{ fontSize: '0.8rem', color: settings.darkMode ? '#aaa' : '#555', marginTop: '8px' }}>
+            Configure Gemini API key to enable analysis
+          </p>
+        )}
+      </div>
+
+      {analysis && (
+        <div style={{ ...styles.card, fontSize: '0.95rem', lineHeight: '1.7', whiteSpace: 'pre-wrap' }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{analysis}</ReactMarkdown>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AISourcesTab;

--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -8,6 +8,7 @@ import CVSSDisplay from './CVSSDisplay';
 import { Brain, Database, Globe, Info, Loader2, Copy, RefreshCw, Package, CheckCircle, XCircle, AlertTriangle, Target, ChevronRight, FileText, ExternalLink, Search, Clock } from 'lucide-react';
 import TechnicalBrief from './TechnicalBrief';
 import ScoreChart from './ScoreChart';
+import AISourcesTab from './AISourcesTab';
 import { vendorPortalMap } from '../utils/vendorPortals';
 
 const CVEDetailView = ({ vulnerability }) => {
@@ -2133,109 +2134,7 @@ Focus on actionable information for security professionals.
             </div>
           )}
 
-          {activeTab === 'ai-sources' && (() => {
-            const cvssRisk = cvssScore >= 9.0 ? 'CRITICAL' : cvssScore >= 7.0 ? 'HIGH' : cvssScore >= 4.0 ? 'MEDIUM' : 'LOW';
-            const epssRisk = vulnerability?.epss?.epssFloat > CONSTANTS.EPSS_THRESHOLDS.HIGH ? 'HIGH' : 
-                            vulnerability?.epss?.epssFloat > CONSTANTS.EPSS_THRESHOLDS.MEDIUM ? 'MEDIUM' : 'LOW';
-            
-            return (
-              <div>
-                <h2 style={{ fontSize: '1.5rem', fontWeight: '700', marginBottom: '24px' }}>
-                  AI-Discovered Intelligence Sources
-                </h2>
-
-                <div style={{
-                  ...styles.card,
-                  marginBottom: '24px',
-                  background: settings.darkMode ? COLORS.dark.background : COLORS.light.background
-                }}>
-                  <div style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '12px',
-                    marginBottom: '16px'
-                  }}>
-                    <Brain size={24} color={COLORS.purple} />
-                    <div>
-                      <h3 style={{
-                        fontSize: '1.125rem',
-                        fontWeight: '600',
-                        margin: 0
-                      }}>
-                        AI Risk Assessment Summary
-                      </h3>
-                      <p style={{
-                        margin: '4px 0 0 0',
-                        fontSize: '0.875rem',
-                        color: settings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText
-                      }}>
-                        Comprehensive analysis of {vulnerability?.cve?.id} based on multiple intelligence sources
-                      </p>
-                    </div>
-                  </div>
-
-                  <div style={{ 
-                    display: 'grid', 
-                    gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', 
-                    gap: '16px',
-                    marginBottom: '20px'
-                  }}>
-                    <div style={{
-                      padding: '16px',
-                      borderRadius: '8px',
-                      background: cvssRisk === 'CRITICAL' ? `rgba(${utils.hexToRgb(COLORS.red)}, 0.1)` :
-                                 cvssRisk === 'HIGH' ? `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.1)` :
-                                 cvssRisk === 'MEDIUM' ? `rgba(${utils.hexToRgb(COLORS.blue)}, 0.1)` : 
-                                 `rgba(${utils.hexToRgb(COLORS.green)}, 0.1)`,
-                      borderWidth: '1px',
-                      borderStyle: 'solid',
-                      borderColor: cvssRisk === 'CRITICAL' ? `rgba(${utils.hexToRgb(COLORS.red)}, 0.3)` :
-                                  cvssRisk === 'HIGH' ? `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.3)` :
-                                  cvssRisk === 'MEDIUM' ? `rgba(${utils.hexToRgb(COLORS.blue)}, 0.3)` : 
-                                  `rgba(${utils.hexToRgb(COLORS.green)}, 0.3)`
-                    }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
-                        <Target size={16} color={
-                          cvssRisk === 'CRITICAL' ? COLORS.red :
-                          cvssRisk === 'HIGH' ? COLORS.yellow :
-                          cvssRisk === 'MEDIUM' ? COLORS.blue : COLORS.green
-                        } />
-                        <div style={{ fontWeight: '600', fontSize: '0.9rem' }}>
-                          CVSS Risk: {cvssRisk}
-                        </div>
-                      </div>
-                      <div style={{ fontSize: '0.8rem', color: settings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                        Score: {cvssScore?.toFixed(1) || 'N/A'}
-                      </div>
-                    </div>
-
-                    <div style={{
-                      padding: '16px',
-                      borderRadius: '8px',
-                      background: epssRisk === 'HIGH' ? `rgba(${utils.hexToRgb(COLORS.red)}, 0.1)` :
-                                 epssRisk === 'MEDIUM' ? `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.1)` :
-                                 `rgba(${utils.hexToRgb(COLORS.green)}, 0.1)`,
-                      borderWidth: '1px',
-                      borderStyle: 'solid',
-                      borderColor: epssRisk === 'HIGH' ? `rgba(${utils.hexToRgb(COLORS.red)}, 0.3)` :
-                                  epssRisk === 'MEDIUM' ? `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.3)` :
-                                  `rgba(${utils.hexToRgb(COLORS.green)}, 0.3)`
-                    }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
-                        <Target size={16} color={epssRisk === 'HIGH' ? COLORS.red : epssRisk === 'MEDIUM' ? COLORS.yellow : COLORS.green} />
-                        <div style={{ fontWeight: '600', fontSize: '0.9rem' }}>
-                          EPSS Risk: {epssRisk}
-                        </div>
-                      </div>
-                      <div style={{ fontSize: '0.8rem', color: settings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText }}>
-                        {vulnerability?.epss?.epssPercentage || 'N/A'}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })()}
+          {activeTab === 'ai-sources' && <AISourcesTab vulnerability={vulnerability} />}
 
           {activeTab === 'patches' && renderEnhancedPatchesTab()}
 

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -29,6 +29,7 @@ import {
   fetchPatchesAndAdvisories as fetchPatchesAndAdvisoriesInternal,
   fetchAIThreatIntelligence as fetchAIThreatIntelligenceInternal,
   generateAIAnalysis as generateAIAnalysisInternal,
+  generateAITaintAnalysis as generateAITaintAnalysisInternal,
   fetchGeneralAnswer as fetchGeneralAnswerInternal,
 } from './AIEnhancementService';
 
@@ -54,6 +55,10 @@ export class APIService {
 
   static async generateAIAnalysis(vulnerability, apiKey, model, settings = {}) {
     return generateAIAnalysisInternal(vulnerability, apiKey, model, settings, ragDatabase, fetchWithFallback, buildEnhancedAnalysisPrompt, generateEnhancedFallbackAnalysis);
+  }
+
+  static async generateAITaintAnalysis(vulnerability, apiKey, model, settings = {}) {
+    return generateAITaintAnalysisInternal(vulnerability, apiKey, model, settings, ragDatabase, fetchWithFallback);
   }
 
   static async fetchGeneralAnswer(query, settings = {}) {

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -231,6 +231,21 @@ export interface TechnicalAnalysisData {
   source?: string; // Where this analysis came from (e.g., 'AI Generated', 'Researcher Blog URL')
 }
 
+export interface TaintFlow {
+  source: string;
+  sink: string;
+  propagation?: string;
+  impact?: string;
+}
+
+export interface TaintAnalysisData {
+  overview?: string;
+  flows?: TaintFlow[];
+  riskAreas?: string[];
+  mitigation?: string[];
+  source?: string;
+}
+
 export interface ThreatActorActivity {
   actorName?: string; // Name of the threat actor/group
   description?: string; // Description of their activity related to this CVE
@@ -392,6 +407,7 @@ export interface EnhancedVulnerabilityData {
   vendorAdvisories?: VendorAdvisoryData | null;
   cveValidation?: CVEValidationData | null; // Updated to new structure
   technicalAnalysis?: TechnicalAnalysisData | null;
+  taintAnalysis?: TaintAnalysisData | null;
   github?: GithubData | null; // Info from GitHub (PoCs, discussions)
   activeExploitation?: ActiveExploitationData | null; // More focused than full ThreatIntel
   threatIntelligence?: ThreatIntelligenceData | null; // Broader threat context


### PR DESCRIPTION
## Summary
- add types for taint analysis
- create `generateAITaintAnalysis` service
- expose new API endpoint via `APIService`
- update AI Sources tab with button to generate taint analysis
- pass vulnerability data to AI Sources tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868984e4844832cb4adc91c9561f2fe