### PR TITLE
Add AI taint analysis feature

### DIFF
--- a/src/components/AISourcesTab.tsx
+++ b/src/components/AISourcesTab.tsx
@@ -1,8 +1,11 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useState, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { AppContext } from '../contexts/AppContext';
 import { createStyles } from '../utils/styles';
+import { APIService } from '../services/APIService';
+import { Brain, Loader2 } from 'lucide-react';
+import { EnhancedVulnerabilityData } from '../types/cveData';
 
 const content = String.raw`# RAG-Powered CVE Conceptual Taint Analysis System
 
@@ -137,13 +140,76 @@ To initiate analysis, provide:
 - **Urgency Level**: Timeline requirements for assessment and remediation
 `;
 
-const AISourcesTab: React.FC = () => {
-  const { settings } = useContext(AppContext);
+interface AISourcesTabProps {
+  vulnerability: EnhancedVulnerabilityData;
+}
+
+const AISourcesTab: React.FC<AISourcesTabProps> = ({ vulnerability }) => {
+  const { settings, addNotification } = useContext(AppContext);
+  const [analysis, setAnalysis] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const styles = useMemo(() => createStyles(settings.darkMode), [settings.darkMode]);
 
+  const generateTaintAnalysis = useCallback(async () => {
+    if (!settings.geminiApiKey) {
+      addNotification?.({ type: 'error', title: 'API Key Required', message: 'Configure Gemini API key in settings' });
+      return;
+    }
+    if (!vulnerability?.cve?.id) {
+      addNotification?.({ type: 'error', title: 'Invalid Vulnerability', message: 'Select a vulnerability first' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const result = await APIService.generateAITaintAnalysis(
+        vulnerability,
+        settings.geminiApiKey,
+        settings.geminiModel,
+        settings
+      );
+      setAnalysis(result.analysis);
+      addNotification?.({ type: 'success', title: 'Taint Analysis Complete', message: 'AI generated taint analysis' });
+    } catch (error: any) {
+      addNotification?.({ type: 'error', title: 'Analysis Failed', message: error.message || 'Failed to generate analysis' });
+    } finally {
+      setLoading(false);
+    }
+  }, [vulnerability, settings, addNotification]);
+
   return (
-    <div style={{ ...styles.card, fontSize: '0.95rem', lineHeight: '1.7', whiteSpace: 'pre-wrap' }}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    <div>
+      <div style={{ ...styles.card, fontSize: '0.95rem', lineHeight: '1.7', whiteSpace: 'pre-wrap', marginBottom: '24px' }}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </div>
+
+      <div style={{ textAlign: 'center', marginBottom: '16px' }}>
+        <button
+          style={{ ...styles.button, ...styles.buttonPrimary, padding: '12px 24px', opacity: loading ? 0.7 : 1 }}
+          onClick={generateTaintAnalysis}
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <Loader2 size={16} style={{ animation: 'spin 1s linear infinite' }} /> Generating Taint Analysis...
+            </>
+          ) : (
+            <>
+              <Brain size={16} /> Generate Taint Analysis
+            </>
+          )}
+        </button>
+        {!settings.geminiApiKey && (
+          <p style={{ fontSize: '0.8rem', color: settings.darkMode ? '#aaa' : '#555', marginTop: '8px' }}>
+            Configure Gemini API key to enable analysis
+          </p>
+        )}
+      </div>
+
+      {analysis && (
+        <div style={{ ...styles.card, fontSize: '0.95rem', lineHeight: '1.7', whiteSpace: 'pre-wrap' }}>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{analysis}</ReactMarkdown>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -2134,7 +2134,7 @@ Focus on actionable information for security professionals.
             </div>
           )}
 
-          {activeTab === 'ai-sources' && <AISourcesTab />}
+          {activeTab === 'ai-sources' && <AISourcesTab vulnerability={vulnerability} />}
 
           {activeTab === 'patches' && renderEnhancedPatchesTab()}
 

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -29,6 +29,7 @@ import {
   fetchPatchesAndAdvisories as fetchPatchesAndAdvisoriesInternal,
   fetchAIThreatIntelligence as fetchAIThreatIntelligenceInternal,
   generateAIAnalysis as generateAIAnalysisInternal,
+  generateAITaintAnalysis as generateAITaintAnalysisInternal,
   fetchGeneralAnswer as fetchGeneralAnswerInternal,
 } from './AIEnhancementService';
 
@@ -54,6 +55,10 @@ export class APIService {
 
   static async generateAIAnalysis(vulnerability, apiKey, model, settings = {}) {
     return generateAIAnalysisInternal(vulnerability, apiKey, model, settings, ragDatabase, fetchWithFallback, buildEnhancedAnalysisPrompt, generateEnhancedFallbackAnalysis);
+  }
+
+  static async generateAITaintAnalysis(vulnerability, apiKey, model, settings = {}) {
+    return generateAITaintAnalysisInternal(vulnerability, apiKey, model, settings, fetchWithFallback);
   }
 
   static async fetchGeneralAnswer(query, settings = {}) {


### PR DESCRIPTION
## Summary
- extend `AISourcesTab` with Gemini-powered taint analysis
- add `generateAITaintAnalysis` method to API services
- update CVE detail view to pass vulnerability to the tab

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868de413d98832c8a6dee86bf9c7c9f