### PR TITLE
Add PatchDiscoveryAgent

### DIFF
--- a/src/agents/PatchDiscoveryAgent.test.ts
+++ b/src/agents/PatchDiscoveryAgent.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PatchDiscoveryAgent } from './PatchDiscoveryAgent';
+import { fetchPatchesAndAdvisories } from '../services/AIEnhancementService';
+
+vi.mock('../services/AIEnhancementService', () => ({
+  fetchPatchesAndAdvisories: vi.fn().mockResolvedValue({
+    patches: [],
+    advisories: [],
+    searchSummary: { patchesFound: 0, advisoriesFound: 0 }
+  })
+}));
+
+describe('PatchDiscoveryAgent', () => {
+  it('identifies vendor portals and calls patch search', async () => {
+    const agent = new PatchDiscoveryAgent();
+    const res = await agent.discover(
+      'CVE-0000-0000',
+      'This vulnerability affects the Apache HTTP Server and allows remote code execution.',
+      {}
+    );
+    expect(res.components[0].name).toBe('Apache HTTP Server');
+    expect(res.vendorPortals.length).toBeGreaterThan(0);
+    expect(fetchPatchesAndAdvisories).toHaveBeenCalled();
+  });
+});

--- a/src/agents/PatchDiscoveryAgent.ts
+++ b/src/agents/PatchDiscoveryAgent.ts
@@ -1,0 +1,55 @@
+import { fetchPatchesAndAdvisories } from '../services/AIEnhancementService';
+import { extractAffectedComponents, DetectedComponent } from '../utils/componentUtils';
+import { vendorPortalMap } from '../utils/vendorPortals';
+import type { AgentSettings, PatchData } from '../types/cveData';
+
+export interface PatchDiscoveryResult {
+  components: DetectedComponent[];
+  vendorPortals: any[];
+  patchData: PatchData;
+}
+
+export class PatchDiscoveryAgent {
+  private setLoadingSteps: (stepsUpdater: (prev: string[]) => string[]) => void;
+
+  constructor(setLoadingSteps?: (stepsUpdater: (prev: string[]) => string[]) => void) {
+    this.setLoadingSteps = setLoadingSteps || (() => {});
+  }
+
+  private updateSteps(message: string) {
+    this.setLoadingSteps(prev => [...prev, message]);
+  }
+
+  async discover(
+    cveId: string,
+    description: string,
+    settings: AgentSettings
+  ): Promise<PatchDiscoveryResult> {
+    this.updateSteps(`🔍 PatchDiscoveryAgent analyzing ${cveId}...`);
+
+    const components = extractAffectedComponents(description);
+    const vendorPortals = components
+      .map(c => vendorPortalMap[c.ecosystem])
+      .filter(Boolean)
+      .map(portal => ({ ...portal }));
+
+    if (vendorPortals.length > 0) {
+      this.updateSteps(
+        `🌐 Vendor portals identified: ${vendorPortals.map(p => p.name).join(', ')}`
+      );
+    } else {
+      this.updateSteps('ℹ️ No specific vendor portals found');
+    }
+
+    const cveData = { description } as any;
+    const patchData = await fetchPatchesAndAdvisories(
+      cveId,
+      cveData,
+      settings,
+      this.setLoadingSteps
+    );
+
+    this.updateSteps(`✅ Patch discovery complete for ${cveId}`);
+    return { components, vendorPortals, patchData };
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -3,3 +3,4 @@ export * from './RAGCuratorAgent';
 export * from './UserAssistantAgent';
 export * from './ValidationAgent';
 export * from './RiskAssessmentAgent';
+export * from './PatchDiscoveryAgent';


### PR DESCRIPTION
## Summary
- add PatchDiscoveryAgent for identifying vendor portals and searching for patches
- test new agent
- export agent from index

## Testing
- `npx vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6869006af938832cbe0a7dba6f3a16cc