### PR TITLE
Add taint analysis engine with CVE mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "acorn": "^8.15.0",
+        "acorn-walk": "^8.3.4",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -2113,9 +2115,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2133,6 +2135,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/adler-32": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "acorn": "^8.15.0",
+    "acorn-walk": "^8.3.4",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/src/analysis/CVEMapping.ts
+++ b/src/analysis/CVEMapping.ts
@@ -1,0 +1,19 @@
+export interface CVEEntry {
+  id: string;
+  functions: string[];
+  library?: string;
+  description: string;
+  severity: string;
+}
+
+export function buildCVEMap(entries: CVEEntry[]): Map<string, CVEEntry[]> {
+  const map = new Map<string, CVEEntry[]>();
+  for (const entry of entries) {
+    for (const fn of entry.functions) {
+      const list = map.get(fn) || [];
+      list.push(entry);
+      map.set(fn, list);
+    }
+  }
+  return map;
+}

--- a/src/analysis/ReportGenerator.ts
+++ b/src/analysis/ReportGenerator.ts
@@ -1,0 +1,5 @@
+import { AnalysisResult } from './TaintAnalyzer';
+
+export function generateJSONReport(result: AnalysisResult) {
+  return JSON.stringify(result, null, 2);
+}

--- a/src/analysis/TaintAnalyzer.test.ts
+++ b/src/analysis/TaintAnalyzer.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { TaintAnalyzer } from './TaintAnalyzer';
+import { buildCVEMap, CVEEntry } from './CVEMapping';
+
+describe('TaintAnalyzer', () => {
+  it('detects tainted flow to sink with CVE', () => {
+    const entries: CVEEntry[] = [
+      { id: 'CVE-2022-0001', functions: ['eval'], description: 'Eval vulnerability', severity: 'HIGH' }
+    ];
+    const map = buildCVEMap(entries);
+    const analyzer = new TaintAnalyzer(map);
+    const code = `
+      function input() { return 'bad'; }
+      const user = input();
+      eval(user);
+    `;
+    const res = analyzer.analyze(code);
+    expect(res.flows.length).toBe(1);
+    expect(res.flows[0].sink.cve?.id).toBe('CVE-2022-0001');
+  });
+
+  it('ignores safe code', () => {
+    const map = buildCVEMap([]);
+    const analyzer = new TaintAnalyzer(map);
+    const code = `
+      const a = 1;
+      eval(a);
+    `;
+    const res = analyzer.analyze(code);
+    expect(res.flows.length).toBe(0);
+  });
+});

--- a/src/analysis/TaintAnalyzer.ts
+++ b/src/analysis/TaintAnalyzer.ts
@@ -1,0 +1,97 @@
+export interface SourceInfo {
+  name: string;
+  loc?: any;
+}
+
+export interface SinkInfo {
+  name: string;
+  loc?: any;
+  cve?: CVEInfo;
+}
+
+export interface CVEInfo {
+  id: string;
+  description: string;
+  severity: string;
+}
+
+export interface TaintFlow {
+  source: SourceInfo;
+  sink: SinkInfo;
+  chain: string[];
+}
+
+export interface AnalysisResult {
+  flows: TaintFlow[];
+}
+
+const TAINT_SOURCES = ['input', 'readFile', 'readFileSync', 'fetch', 'axios'];
+const TAINT_SINKS = ['eval', 'exec', 'execSync', 'spawn', 'query'];
+
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+
+export class TaintAnalyzer {
+  private cveMap: Map<string, CVEInfo[]>;
+
+  constructor(cveMap: Map<string, CVEInfo[]>) {
+    this.cveMap = cveMap;
+  }
+
+  analyze(code: string): AnalysisResult {
+    const ast = acorn.parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
+    const taintedVars: Map<string, SourceInfo> = new Map();
+    const flows: TaintFlow[] = [];
+
+    walk.simple(ast as any, {
+      VariableDeclarator: (node: any) => {
+        if (node.init) {
+          if (this.isSourceCall(node.init)) {
+            taintedVars.set(node.id.name, { name: node.init.callee.name, loc: node.loc });
+          } else if (node.init.type === 'Identifier' && taintedVars.has(node.init.name)) {
+            taintedVars.set(node.id.name, taintedVars.get(node.init.name)!);
+          }
+        }
+      },
+      AssignmentExpression: (node: any) => {
+        if (node.right.type === 'Identifier' && taintedVars.has(node.right.name)) {
+          if (node.left.type === 'Identifier') {
+            taintedVars.set(node.left.name, taintedVars.get(node.right.name)!);
+          }
+        }
+      },
+      CallExpression: (node: any) => {
+        const calleeName = this.getCalleeName(node.callee);
+        if (!calleeName) return;
+        if (TAINT_SINKS.includes(calleeName)) {
+          const arg = node.arguments[0];
+          if (arg && arg.type === 'Identifier' && taintedVars.has(arg.name)) {
+            const source = taintedVars.get(arg.name)!;
+            const chain = [source.name, arg.name, calleeName];
+            const cve = this.cveMap.get(calleeName)?.[0];
+            flows.push({ source, sink: { name: calleeName, loc: node.loc, cve }, chain });
+          }
+        }
+        // propagate through function returns (simplified: first arg to variable)
+      }
+    });
+
+    return { flows };
+  }
+
+  private isSourceCall(node: any): boolean {
+    if (node.type !== 'CallExpression') return false;
+    const name = this.getCalleeName(node.callee);
+    return name ? TAINT_SOURCES.includes(name) : false;
+  }
+
+  private getCalleeName(callee: any): string | null {
+    if (callee.type === 'Identifier') {
+      return callee.name;
+    }
+    if (callee.type === 'MemberExpression' && !callee.computed && callee.property.type === 'Identifier') {
+      return callee.property.name;
+    }
+    return null;
+  }
+}

--- a/src/analysis/index.ts
+++ b/src/analysis/index.ts
@@ -1,0 +1,3 @@
+export * from './TaintAnalyzer';
+export * from './CVEMapping';
+export * from './ReportGenerator';


### PR DESCRIPTION
## Summary
- implement `TaintAnalyzer` for simple source-to-sink tracking
- map CVE entries to vulnerable functions
- generate JSON security reports
- test taint engine
- add `acorn` and `acorn-walk` for JS parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bacdbff28832cac335915cabebf3f