### PR TITLE
Centralize CVE regex

### DIFF
--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -18,8 +18,7 @@ import {
 } from '../types/cveData';
 import { generateRemediationPlan } from '../utils/remediation';
 import { extractComponentNames } from '../utils/componentUtils';
-
-const CVE_REGEX = /CVE-\d{4}-\d{4,7}/gi;
+import { CVE_REGEX } from '../utils/cveRegex';
 
 interface ConversationContext {
   currentTopic?: string;

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -19,8 +19,7 @@ import {
 import { generateRemediationPlan } from '../utils/remediation';
 import { extractComponentNames } from '../utils/componentUtils';
 import { CONSTANTS } from '../utils/constants';
-
-const CVE_REGEX = /CVE-\d{4}-\d{4,7}/gi;
+import { CVE_REGEX } from '../utils/cveRegex';
 
 interface ConversationContext {
   currentTopic?: string;

--- a/src/services/FileParserService.ts
+++ b/src/services/FileParserService.ts
@@ -1,6 +1,5 @@
 // Regex to identify CVE patterns (e.g., CVE-YYYY-NNNN or CVE-YYYY-NNNNN...)
-// This should be kept consistent with the one in UserAssistantAgent.ts or centralized if used in many places.
-const CVE_REGEX = /CVE-\d{4}-\d{4,7}/gi; // Added 'g' flag for global match
+import { CVE_REGEX } from '../utils/cveRegex';
 
 /**
  * Reads a CSV file and extracts all valid CVE ID patterns from its content.

--- a/src/utils/cveRegex.ts
+++ b/src/utils/cveRegex.ts
@@ -1,0 +1,3 @@
+// Centralized regex for matching CVE identifiers like "CVE-YYYY-NNNN" or "CVE-YYYY-NNNNN...".
+// The regex is case-insensitive and global to allow multiple matches.
+export const CVE_REGEX = /CVE-\d{4}-\d{4,7}/gi;


### PR DESCRIPTION
## Summary
- add `src/utils/cveRegex.ts` exporting a single regex constant
- import and use this constant in `UserAssistantAgent` and `FileParserService`
- update agent unit tests to use the shared regex

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1246fcac832cafbcb7c9f3363699