### PR TITLE
Add configurable cache TTL to UserAssistantAgent

### DIFF
--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -64,4 +64,24 @@ describe('UserAssistantAgent', () => {
     const summary = agent.generateBulkAnalysisSummary();
     expect(summary.text).toContain("don't have any bulk analysis results");
   });
+
+  it('respects custom cache TTL', async () => {
+    const agent = new UserAssistantAgent({ cacheTTL: 0 });
+    const fetcher = vi.fn().mockResolvedValueOnce('a').mockResolvedValueOnce('b');
+    const res1 = await (agent as any).getCachedOrFetch('k', fetcher);
+    const res2 = await (agent as any).getCachedOrFetch('k', fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(res1).toBe('a');
+    expect(res2).toBe('b');
+  });
+
+  it('clearCache forces refetch', async () => {
+    const agent = new UserAssistantAgent({ cacheTTL: 10000 });
+    const fetcher = vi.fn().mockResolvedValueOnce('a').mockResolvedValueOnce('b');
+    await (agent as any).getCachedOrFetch('k', fetcher);
+    agent.clearCache();
+    const res = await (agent as any).getCachedOrFetch('k', fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(res).toBe('b');
+  });
 });

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -454,6 +454,7 @@ export interface AgentSettings {
   geminiModel?: string;
   openAiApiKey?: string;
   openAiModel?: string;
+  cacheTTL?: number; // TTL for caching in milliseconds
   [key: string]: any; // Allow other settings
 }
 


### PR DESCRIPTION
## Summary
- extend `AgentSettings` with optional `cacheTTL` parameter
- respect `cacheTTL` in `UserAssistantAgent` and provide `clearCache`
- add tests for TTL override and cache clearing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e14c3a0fc832c8aaec7a36b968d1f