### PR TITLE
Enhance assistant agent with contextual memory

### DIFF
--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -465,6 +465,8 @@ export interface ChatResponse<T = any> {
   // For UserAssistantAgent
   id?: string;
   sender?: 'user' | 'bot' | 'system';
+  confidence?: number;
+  followUps?: string[];
 }
 
 export interface BulkAnalysisResult {


### PR DESCRIPTION
## Summary
- extend `ChatResponse` to include `confidence` and `followUps`
- track recent intents in conversation context
- add query analysis helpers for intent detection and sentiment
- implement follow-up suggestions and confidence in `handleQuery`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e4defab18832c8b07c10b8b8ac625