### PR TITLE
Fix missing dispute detection helper

### DIFF
--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -84,4 +84,10 @@ describe('UserAssistantAgent', () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
     expect(res).toBe('b');
   });
+
+  it('isActualDispute detects dispute keywords', () => {
+    const agent = new UserAssistantAgent();
+    const res = (agent as any).isActualDispute('Vendor disputes this issue and marked as false positive', 'CVE-2023-1234');
+    expect(res).toBe(true);
+  });
 });

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -456,6 +456,35 @@ export class UserAssistantAgent {
     return 0;
   }
 
+  // Legacy keyword-based dispute detection used as a fallback
+  private isActualDispute(text: string, cveId: string): boolean {
+    if (!text) return false;
+    const lower = text.toLowerCase();
+    const indicators = [
+      'vendor dispute',
+      'vendor disputes',
+      'false positive',
+      'not a vulnerability',
+      'rejected',
+      'withdrawn',
+      'invalid',
+      "won't fix",
+      'wontfix',
+      'not exploitable',
+      'no patch because',
+      'excluded'
+    ];
+
+    if (cveId) {
+      const idLower = cveId.toLowerCase();
+      if (lower.includes(`rejected ${idLower}`) || lower.includes(`withdrawn ${idLower}`)) {
+        return true;
+      }
+    }
+
+    return indicators.some(ind => lower.includes(ind));
+  }
+
   // Combine traditional and ML dispute analysis
   private combineDisputeAnalysis(traditionalResult: boolean, mlResult: any): {
     isDisputed: boolean;


### PR DESCRIPTION
## Summary
- implement `isActualDispute` in `UserAssistantAgent`
- test dispute detection logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e5c4a293c832c863f553338faa0c9