### PR TITLE
Fix OpenAI requests with invalid tool parameter

### DIFF
--- a/src/services/AIEnhancementService.test.ts
+++ b/src/services/AIEnhancementService.test.ts
@@ -8,11 +8,11 @@ const mockResponse = {
 } as any;
 
 describe('fetchGeneralAnswer', () => {
-  it('includes web search tool when using OpenAI', async () => {
+  it('omits unsupported tool field when using OpenAI', async () => {
     const fetcher = vi.fn().mockResolvedValue(mockResponse);
     await fetchGeneralAnswer('hi', { openAiApiKey: 'key', openAiModel: 'gpt-4o' }, fetcher);
     const options = fetcher.mock.calls[0][1];
     const body = JSON.parse(options.body);
-    expect(body.tools).toEqual([{ type: 'web-search' }]);
+    expect(body.tools).toBeUndefined();
   });
 });

--- a/src/services/AIEnhancementService.ts
+++ b/src/services/AIEnhancementService.ts
@@ -233,8 +233,7 @@ CRITICAL: You MUST show the extraction results in your response. Do NOT skip the
         }
       : {
           model,
-          messages: [{ role: 'user', content: analysisPrompt }],
-          tools: [{ type: 'web-search' }]
+          messages: [{ role: 'user', content: analysisPrompt }]
         };
 
     updateSteps(prev => [...prev, `🔍 AI analyzing description and extracting vendor details...`]);
@@ -377,8 +376,7 @@ export async function fetchAIThreatIntelligence(
         }
       : {
           model,
-          messages: [{ role: 'user', content: searchPrompt }],
-          tools: [{ type: 'web-search' }]
+          messages: [{ role: 'user', content: searchPrompt }]
         };
 
     const apiUrl = useGemini
@@ -975,8 +973,6 @@ export async function generateAIAnalysis(vulnerability, apiKey, model, settings 
   const isWebSearchCapable = useGemini && (model.includes('2.0') || model.includes('2.5'));
   if (useGemini && isWebSearchCapable) {
     requestBody.tools = [{ google_search: {} }];
-  } else if (!useGemini) {
-    requestBody.tools = [{ type: 'web-search' }];
   }
 
   const apiUrl = useGemini
@@ -1092,8 +1088,7 @@ export async function fetchGeneralAnswer(query: string, settings: any, fetchWith
       }
       : {
           model,
-          messages: [{ role: 'user', content: query }],
-          tools: [{ type: 'web-search' }]
+          messages: [{ role: 'user', content: query }]
         };
   const apiUrl = useGemini
     ? `${CONSTANTS.API_ENDPOINTS.GEMINI}/${model}:generateContent?key=${settings.geminiApiKey}`
@@ -1136,15 +1131,12 @@ export async function generateAITaintAnalysis(
       }
     : {
         model: settings.openAiModel || 'gpt-4o',
-        messages: [{ role: 'user', content: prompt }],
-        tools: [{ type: 'web-search' }]
+        messages: [{ role: 'user', content: prompt }]
       };
 
   const isWebSearchCapable = useGemini && (model.includes('2.0') || model.includes('2.5'));
   if (useGemini && isWebSearchCapable) {
     requestBody.tools = [{ google_search: {} }];
-  } else if (!useGemini) {
-    requestBody.tools = [{ type: 'web-search' }];
   }
 
   const apiUrl = useGemini


### PR DESCRIPTION
## Summary
- remove unsupported `web-search` tool from OpenAI request bodies
- adjust taint analysis and RAG helpers
- update tests to match new request payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f52c03abc832c8ac3729e5eba5abc