### PR TITLE
Fix parsing of AI responses

### DIFF
--- a/src/services/AIEnhancementService.test.ts
+++ b/src/services/AIEnhancementService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fetchGeneralAnswer } from './AIEnhancementService';
+import { fetchGeneralAnswer, parseDescriptionBasedResponse } from './AIEnhancementService';
 
 // Simple mock response for OpenAI
 const mockResponse = {
@@ -14,5 +14,15 @@ describe('fetchGeneralAnswer', () => {
     const options = fetcher.mock.calls[0][1];
     const body = JSON.parse(options.body);
     expect(body.tools).toBeUndefined();
+  });
+});
+
+describe('parseDescriptionBasedResponse', () => {
+  it('extracts JSON surrounded by text', () => {
+    const text = 'Intro text\n```json\n{ "patches": [], "advisories": [] }\n```\ntrailing';
+    const result = parseDescriptionBasedResponse(text, 'CVE-TEST');
+    expect(result.patches).toEqual([]);
+    expect(result.advisories).toEqual([]);
+    expect(result.searchSummary.patchesFound).toBe(0);
   });
 });

--- a/src/services/AIEnhancementService.ts
+++ b/src/services/AIEnhancementService.ts
@@ -709,11 +709,17 @@ function extractVersionFromUrl(url: string): string | null {
 /**
  * Parse response that includes description analysis
  */
-function parseDescriptionBasedResponse(response: string, cveId: string): any {
+export function parseDescriptionBasedResponse(response: string, cveId: string): any {
   try {
-    const jsonMatch = response.match(/\{[\s\S]*\}/);
-    if (jsonMatch) {
-      const data = JSON.parse(jsonMatch[0]);
+    // Remove common code block markers and trim
+    let cleaned = response.replace(/```(?:json)?/gi, '').trim();
+
+    // Isolate the first JSON object in the response
+    const first = cleaned.indexOf('{');
+    const last = cleaned.lastIndexOf('}');
+    if (first !== -1 && last !== -1 && last > first) {
+      const jsonString = cleaned.slice(first, last + 1);
+      const data = JSON.parse(jsonString);
       
       // Extract the core patch/advisory data while preserving analysis steps
       const result = {


### PR DESCRIPTION
## Summary
- make `parseDescriptionBasedResponse` more robust and export it
- add unit test for parsing responses with text surrounding JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f6523bf9c832cb2a4622266abefd4