### PR TITLE
Fix OpenAI web search payload

### DIFF
--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -217,7 +217,7 @@ export class UserAssistantAgent {
     if (this.settings.openAiApiKey) {
       try {
         const model = this.settings.openAiModel || 'gpt-4o';
-        const res = await fetch(`${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`, {
+        const res = await fetch(`${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -226,7 +226,7 @@ export class UserAssistantAgent {
           body: JSON.stringify({
             model,
             messages: [{ role: 'user', content: query }],
-            tools: [{ type: 'web_search' }]
+            tools: [{ type: 'function', function: { name: 'web_search' } }]
           })
         });
         if (!res.ok) {

--- a/src/services/AIEnhancementService.test.ts
+++ b/src/services/AIEnhancementService.test.ts
@@ -13,7 +13,7 @@ describe('fetchGeneralAnswer', () => {
     await fetchGeneralAnswer('hi', { openAiApiKey: 'key', openAiModel: 'gpt-4o' }, fetcher);
     const options = fetcher.mock.calls[0][1];
     const body = JSON.parse(options.body);
-    expect(body.tools).toEqual([{ type: 'web_search' }]);
+    expect(body.tools).toEqual([{ type: 'function', function: { name: 'web_search' } }]);
   });
 });
 

--- a/src/services/AIEnhancementService.ts
+++ b/src/services/AIEnhancementService.ts
@@ -234,14 +234,14 @@ CRITICAL: You MUST show the extraction results in your response. Do NOT skip the
       : {
           model,
           messages: [{ role: 'user', content: analysisPrompt }],
-          tools: [{ type: 'web_search' }]
+          tools: [{ type: 'function', function: { name: 'web_search' } }]
         };
 
     updateSteps(prev => [...prev, `🔍 AI analyzing description and extracting vendor details...`]);
 
     const apiUrl = useGemini
       ? `${CONSTANTS.API_ENDPOINTS.GEMINI}/${model}:generateContent?key=${settings.geminiApiKey}`
-      : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+      : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
     const headers: any = { 'Content-Type': 'application/json' };
     if (!useGemini) headers['Authorization'] = `Bearer ${settings.openAiApiKey}`;
 
@@ -378,12 +378,12 @@ export async function fetchAIThreatIntelligence(
       : {
           model,
           messages: [{ role: 'user', content: searchPrompt }],
-          tools: [{ type: 'web_search' }]
+          tools: [{ type: 'function', function: { name: 'web_search' } }]
         };
 
     const apiUrl = useGemini
       ? `${CONSTANTS.API_ENDPOINTS.GEMINI}/${model}:generateContent?key=${settings.geminiApiKey}`
-      : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+      : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
     const headers: any = { 'Content-Type': 'application/json' };
     if (!useGemini) headers['Authorization'] = `Bearer ${settings.openAiApiKey}`;
 
@@ -982,12 +982,12 @@ export async function generateAIAnalysis(vulnerability, apiKey, model, settings 
   if (useGemini && geminiSearchCapable) {
     requestBody.tools = [{ google_search: {} }];
   } else if (!useGemini) {
-    requestBody.tools = [{ type: 'web_search' }];
+    requestBody.tools = [{ type: 'function', function: { name: 'web_search' } }];
   }
 
   const apiUrl = useGemini
     ? `${CONSTANTS.API_ENDPOINTS.GEMINI}/${model}:generateContent?key=${apiKey}`
-    : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+    : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
 
   try {
     const headers: any = { 'Content-Type': 'application/json' };
@@ -1099,11 +1099,11 @@ export async function fetchGeneralAnswer(query: string, settings: any, fetchWith
       : {
           model,
           messages: [{ role: 'user', content: query }],
-          tools: [{ type: 'web_search' }]
+          tools: [{ type: 'function', function: { name: 'web_search' } }]
         };
   const apiUrl = useGemini
     ? `${CONSTANTS.API_ENDPOINTS.GEMINI}/${model}:generateContent?key=${settings.geminiApiKey}`
-    : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+    : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
   const headers: any = { "Content-Type": "application/json" };
   if (!useGemini) headers["Authorization"] = `Bearer ${settings.openAiApiKey}`;
   const response = await fetchWithFallbackFn(apiUrl, {
@@ -1149,12 +1149,12 @@ export async function generateAITaintAnalysis(
   if (useGemini && geminiSearchCapable) {
     requestBody.tools = [{ google_search: {} }];
   } else if (!useGemini) {
-    requestBody.tools = [{ type: 'web_search' }];
+    requestBody.tools = [{ type: 'function', function: { name: 'web_search' } }];
   }
 
   const apiUrl = useGemini
     ? `${CONSTANTS.API_ENDPOINTS.GEMINI}/${model}:generateContent?key=${apiKey}`
-    : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+    : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
   const headers: any = { 'Content-Type': 'application/json' };
   if (!useGemini) headers['Authorization'] = `Bearer ${settings.openAiApiKey}`;
 

--- a/src/services/DataFetchingService.ts
+++ b/src/services/DataFetchingService.ts
@@ -43,7 +43,7 @@ Search terms: CISA Known Exploited Vulnerabilities catalog KEV official list`;
     const model = useGemini ? (aiSettings.geminiModel || 'gemini-2.5-flash') : (aiSettings.openAiModel || 'gpt-4o');
     const apiUrl = useGemini
       ? `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`
-      : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+      : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
 
     const requestBody: any = useGemini
       ? {
@@ -59,7 +59,7 @@ Search terms: CISA Known Exploited Vulnerabilities catalog KEV official list`;
       : {
           model,
           messages: [{ role: 'user', content: searchPrompt }],
-          tools: [{ type: 'web_search' }]
+          tools: [{ type: 'function', function: { name: 'web_search' } }]
         };
 
     const headers: any = { 'Content-Type': 'application/json' };
@@ -508,7 +508,7 @@ Focus on official CISA sources and government advisories. Return specific inform
     const model = useGemini ? (aiSettings.geminiModel || 'gemini-2.5-flash') : (aiSettings.openAiModel || 'gpt-4o');
     const apiUrl = useGemini
       ? `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`
-      : `${CONSTANTS.API_ENDPOINTS.OPENAI}/chat/completions`;
+      : `${CONSTANTS.API_ENDPOINTS.OPENAI_RESPONSES}`;
 
     const requestBody: any = useGemini
       ? {
@@ -524,7 +524,7 @@ Focus on official CISA sources and government advisories. Return specific inform
       : {
           model,
           messages: [{ role: 'user', content: kevSearchPrompt }],
-          tools: [{ type: 'web_search' }]
+          tools: [{ type: 'function', function: { name: 'web_search' } }]
         };
 
     const headers: any = { 'Content-Type': 'application/json' };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,7 +3,8 @@ export const CONSTANTS = {
     NVD: 'https://services.nvd.nist.gov/rest/json/cves/2.0',
     EPSS: 'https://api.first.org/data/v1/epss',
     GEMINI: 'https://generativelanguage.googleapis.com/v1beta/models',
-    OPENAI: 'https://api.openai.com/v1'
+    OPENAI: 'https://api.openai.com/v1',
+    OPENAI_RESPONSES: 'https://api.openai.com/v1/responses'
   },
   RATE_LIMITS: {
     GEMINI_COOLDOWN: 60000, // 1 minute


### PR DESCRIPTION
## Summary
- fix request bodies for OpenAI web search
- keep tests in sync
- use /v1/responses endpoint for internet

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687fc261e3b8832cbd542eb52e220e6e