### PR TITLE
Improve CVSS severity handling

### DIFF
--- a/src/components/CVSSDisplay.tsx
+++ b/src/components/CVSSDisplay.tsx
@@ -53,6 +53,40 @@ const CVSSDisplay = ({ vulnerability }) => {
         </div>
       </div>
 
+      <div style={{
+        marginBottom: '12px',
+        display: 'inline-block',
+        padding: '6px 12px',
+        borderRadius: '6px',
+        fontSize: '0.8125rem',
+        fontWeight: '700',
+        background: severity === 'CRITICAL'
+          ? 'rgba(239, 68, 68, 0.15)'
+          : severity === 'HIGH'
+          ? 'rgba(245, 158, 11, 0.15)'
+          : severity === 'MEDIUM'
+          ? 'rgba(59, 130, 246, 0.15)'
+          : 'rgba(34, 197, 94, 0.15)',
+        color: severity === 'CRITICAL'
+          ? COLORS.red
+          : severity === 'HIGH'
+          ? COLORS.yellow
+          : severity === 'MEDIUM'
+          ? COLORS.blue
+          : COLORS.green,
+        borderWidth: '1px',
+        borderStyle: 'solid',
+        borderColor: severity === 'CRITICAL'
+          ? 'rgba(239, 68, 68, 0.3)'
+          : severity === 'HIGH'
+          ? 'rgba(245, 158, 11, 0.3)'
+          : severity === 'MEDIUM'
+          ? 'rgba(59, 130, 246, 0.3)'
+          : 'rgba(34, 197, 94, 0.3)'
+      }}>
+        {severity} Severity
+      </div>
+
       {vulnerability.epss && (
         <div style={{
           background: `rgba(${utils.hexToRgb(COLORS.purple)}, 0.1)`,

--- a/src/services/UtilityService.test.ts
+++ b/src/services/UtilityService.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { buildConversationalAnalysisPrompt } from './UtilityService'
+
+// This test ensures severity is derived from CVSS score when not provided
+
+describe('buildConversationalAnalysisPrompt', () => {
+  it('derives severity from CVSS score', () => {
+    const vuln = {
+      cve: {
+        id: 'CVE-TEST-0001',
+        description: 'Test vuln',
+        cvssV3: {
+          baseScore: 8.2
+          // intentionally omit baseSeverity
+        }
+      },
+      epss: { epss: '0.1' }
+    } as any
+
+    const prompt = buildConversationalAnalysisPrompt(vuln)
+    expect(prompt).toContain('8.2 CVSS (HIGH)')
+  })
+})

--- a/src/services/UtilityService.ts
+++ b/src/services/UtilityService.ts
@@ -765,9 +765,22 @@ function extractCVSSInfo(cveData: any): any {
     cvssData = cvssV31 || cvssV30 || {};
   }
   
+  cvssScore = cvssData.baseScore || 'Not available';
+  baseSeverity = cvssData.baseSeverity || 'Not available';
+
+  if (baseSeverity === 'Not available' && cvssScore !== 'Not available') {
+    const scoreNum = parseFloat(cvssScore);
+    if (!isNaN(scoreNum)) {
+      if (scoreNum >= 9.0) baseSeverity = 'CRITICAL';
+      else if (scoreNum >= 7.0) baseSeverity = 'HIGH';
+      else if (scoreNum >= 4.0) baseSeverity = 'MEDIUM';
+      else baseSeverity = 'LOW';
+    }
+  }
+
   return {
-    score: cvssData.baseScore || 'Not available',
-    severity: cvssData.baseSeverity || 'Not available',
+    score: cvssScore,
+    severity: baseSeverity,
     vectorString: cvssData.vectorString || 'Not available',
     attackVector: cvssData.attackVector || 'Unknown',
     attackComplexity: cvssData.attackComplexity || 'Unknown',
@@ -1072,7 +1085,17 @@ function extractCVSSScore(cveData: any): { score: string, severity: string } {
     cvssScore = cvssData.baseScore?.toString() || 'Not available';
     baseSeverity = cvssData.baseSeverity || 'Not available';
   }
-  
+
+  if (baseSeverity === 'Not available' && cvssScore !== 'Not available') {
+    const scoreNum = parseFloat(cvssScore);
+    if (!isNaN(scoreNum)) {
+      if (scoreNum >= 9.0) baseSeverity = 'CRITICAL';
+      else if (scoreNum >= 7.0) baseSeverity = 'HIGH';
+      else if (scoreNum >= 4.0) baseSeverity = 'MEDIUM';
+      else baseSeverity = 'LOW';
+    }
+  }
+
   return { score: cvssScore, severity: baseSeverity };
 }
 


### PR DESCRIPTION
## Summary
- derive severity from CVSS score when not provided
- display the derived severity badge in the overview sidebar
- add test for severity derivation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688208d555b8832c8f93035df70f39f2