### PR TITLE
Fix Gemini search field, add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/ai-web-search.js
+++ b/scripts/ai-web-search.js
@@ -24,7 +24,7 @@ async function run() {
           maxOutputTokens: 1024,
           candidateCount: 1
         },
-        tools: [{ google_search: {} }]
+        tools: [{ google_search_retrieval: {} }]
       }
       const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro-latest:generateContent?key=${geminiKey}`
       const response = await fetch(url, {

--- a/src/services/AIEnhancementService.ts
+++ b/src/services/AIEnhancementService.ts
@@ -161,7 +161,7 @@ Please provide information about any patches, updates, or advisories you find fo
           maxOutputTokens: 4096,
           candidateCount: 1
         },
-        tools: [{ google_search: {} }]
+        tools: [{ google_search_retrieval: {} }]
       }
     : openAiSearchCapable
       ? {
@@ -413,7 +413,7 @@ Provide specific information about any threats, exploits, or active usage you fi
             maxOutputTokens: 4096,
             candidateCount: 1
           },
-          tools: [{ google_search: {} }]
+          tools: [{ google_search_retrieval: {} }]
         } 
       : {
           // FIXED: OpenAI /responses endpoint format
@@ -624,7 +624,7 @@ export async function generateAIAnalysis(
         };
 
   if (useGemini && geminiSearchCapable) {
-    requestBody.tools = [{ google_search: {} }];
+    requestBody.tools = [{ google_search_retrieval: {} }];
   }
 
   const apiUrl = useGemini
@@ -802,7 +802,7 @@ export async function fetchGeneralAnswer(query: string, settings: any, fetchWith
           maxOutputTokens: 1024, 
           candidateCount: 1 
         },
-        tools: geminiSearchCapable ? [{ google_search: {} }] : undefined
+        tools: geminiSearchCapable ? [{ google_search_retrieval: {} }] : undefined
       }
     : openAiSearchCapable
       ? {
@@ -914,7 +914,7 @@ export async function generateAITaintAnalysis(
           maxOutputTokens: 2048, 
           candidateCount: 1 
         },
-        tools: geminiSearchCapable ? [{ google_search: {} }] : undefined
+        tools: geminiSearchCapable ? [{ google_search_retrieval: {} }] : undefined
       }
     : openAiSearchCapable
       ? {

--- a/src/services/DataFetchingService.ts
+++ b/src/services/DataFetchingService.ts
@@ -54,7 +54,7 @@ async function fetchWithAIWebSearch(url: string, aiSettings: any, specificQuery?
       apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${activeSettings.geminiApiKey}`;
       requestBody = {
         contents: [{ parts: [{ text: searchPrompt }] }],
-        tools: [{ google_search: {} }], // Gemini's native web search
+        tools: [{ google_search_retrieval: {} }], // Gemini's native web search
         generationConfig: {
           temperature: 0.1,
           topK: 40,


### PR DESCRIPTION
## Summary
- replace deprecated `google_search` in Gemini requests with `google_search_retrieval`
- add missing MIT license file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688210b66aac832cb008c47966eb5420