### PR TITLE
Fix: Correct Gemini API request body for search grounding

### DIFF
--- a/src/services/DataFetchingService.ts
+++ b/src/services/DataFetchingService.ts
@@ -61,7 +61,9 @@ async function fetchWithAIWebSearch(url: string, aiSettings: any, specificQuery?
       apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${activeSettings.geminiApiKey}`;
       requestBody = {
         contents: [{ parts: [{ text: searchPrompt }] }],
-        tools: [{ google_search_retrieval: {} }], // Gemini's native web search
+        config: {
+          tools: [{ "googleSearch": {} }],
+        },
         generationConfig: {
           temperature: 0.1,
           topK: 40,


### PR DESCRIPTION
This commit fixes a bug that was causing the Gemini API to return a "Search Grounding is not supported" error. The `requestBody` for the Gemini API call in `DataFetchingService.ts` was not structured correctly.

The `tools` array is now correctly wrapped in a `config` object, and the `google_search_retrieval` key has been replaced with `googleSearch`, as per the API documentation.