### PR TITLE
Fix: Correct Gemini API request body for search grounding

### DIFF
--- a/src/services/DataFetchingService.ts
+++ b/src/services/DataFetchingService.ts
@@ -61,9 +61,7 @@ async function fetchWithAIWebSearch(url: string, aiSettings: any, specificQuery?
       apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${activeSettings.geminiApiKey}`;
       requestBody = {
         contents: [{ parts: [{ text: searchPrompt }] }],
-        config: {
-          tools: [{ "googleSearch": {} }],
-        },
+        tools: [{ "google_search": {} }],
         generationConfig: {
           temperature: 0.1,
           topK: 40,


### PR DESCRIPTION
This commit fixes a bug that was causing the Gemini API to return an "Invalid JSON payload" error. The `requestBody` for the Gemini API call in `DataFetchingService.ts` was not structured correctly.

The `config` object has been removed, and the `google_search` key is now used directly in the `tools` array, as per the REST API documentation.