### PR TITLE
Improve error reporting in Gemini fetch

### DIFF
--- a/src/services/UtilityService.test.ts
+++ b/src/services/UtilityService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildConversationalAnalysisPrompt } from './UtilityService'
+import { buildConversationalAnalysisPrompt, fetchWithFallback } from './UtilityService'
 
 // This test ensures severity is derived from CVSS score when not provided
 
@@ -19,5 +19,21 @@ describe('buildConversationalAnalysisPrompt', () => {
 
     const prompt = buildConversationalAnalysisPrompt(vuln)
     expect(prompt).toContain('8.2 CVSS (HIGH)')
+  })
+})
+
+describe('fetchWithFallback', () => {
+  it('uses error message from JSON response', async () => {
+    const originalFetch = global.fetch
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: () => Promise.resolve(JSON.stringify({ error: { message: 'Invalid key' } }))
+    }) as any
+
+    await expect(fetchWithFallback('http://test', {}, 1)).rejects.toThrow('Invalid key')
+
+    global.fetch = originalFetch
   })
 })

--- a/src/services/UtilityService.ts
+++ b/src/services/UtilityService.ts
@@ -15,7 +15,25 @@ export async function fetchWithFallback(url: string, options: RequestInit = {}, 
       });
       
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        let errorDetail = response.statusText;
+        try {
+          const text = await response.text();
+          if (text) {
+            try {
+              const data = JSON.parse(text);
+              if (data.error?.message) {
+                errorDetail = data.error.message;
+              } else {
+                errorDetail = text;
+              }
+            } catch {
+              errorDetail = text;
+            }
+          }
+        } catch {
+          // ignore
+        }
+        throw new Error(`HTTP ${response.status}: ${errorDetail}`);
       }
       
       return response;


### PR DESCRIPTION
## Summary
- parse JSON error details in `fetchWithFallback`
- test that `fetchWithFallback` propagates Gemini error message

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68824f5fe848832cb42c2a8fca194388