### PR TITLE
Fix missing COLORS constant

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -27,6 +27,32 @@ export const CONSTANTS = {
   }
 };
 
+export const COLORS = {
+  blue: '#3b82f6',
+  purple: '#8b5cf6',
+  green: '#22c55e',
+  red: '#ef4444',
+  yellow: '#f59e0b',
+  dark: {
+    background: '#0f172a',
+    surface: '#1e293b',
+    primaryText: '#f1f5f9',
+    secondaryText: '#94a3b8',
+    tertiaryText: '#64748b',
+    border: '#334155',
+    shadow: 'rgba(0, 0, 0, 0.2)'
+  },
+  light: {
+    background: '#f8fafc',
+    surface: '#ffffff',
+    primaryText: '#0f172a',
+    secondaryText: '#64748b',
+    tertiaryText: '#94a3b8',
+    border: '#e2e8f0',
+    shadow: 'rgba(0, 0, 0, 0.07)'
+  }
+};
+
 // Updated AIEnhancementService functions to properly use OpenAI Responses API
 
 /**


### PR DESCRIPTION
## Summary
- restore `COLORS` export in `constants.ts` to resolve build errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688263abbef8832c979487d6ec02a8b1