### PR TITLE
Add custom RAG prompt and improve learning metrics

### DIFF
--- a/src/agents/ResearchAgent.ts
+++ b/src/agents/ResearchAgent.ts
@@ -472,8 +472,28 @@ class ContinuousLearningSystem {
   }
 
   private calculateAccuracy(prediction: any, actual: any): number {
-    // Simple accuracy calculation
-    return 0.7; // Placeholder
+    let score = 0;
+    if (prediction.vendor && actual.vendor) {
+      if (
+        prediction.vendor.toLowerCase() === actual.vendor.toLowerCase()
+      ) {
+        score += 0.4;
+      }
+    }
+    if (
+      typeof prediction.severity === 'number' &&
+      typeof actual.severity === 'number'
+    ) {
+      const diff = Math.abs(prediction.severity - actual.severity);
+      score += diff < 1 ? 0.4 : diff < 2 ? 0.2 : 0;
+    }
+    if (
+      prediction.exploited !== undefined &&
+      actual.exploited !== undefined
+    ) {
+      score += prediction.exploited === actual.exploited ? 0.2 : 0;
+    }
+    return Math.round(score * 100) / 100;
   }
 
   async collectUserFeedback(analysisId: string, feedback: any): Promise<void> {
@@ -494,9 +514,13 @@ class ContinuousLearningSystem {
   }
 
   getAccuracyMetrics(): any {
+    const values = Array.from(this.metrics.values());
+    const overall =
+      values.reduce((sum, m) => sum + (m.accuracy || 0), 0) /
+      (values.length || 1);
     return {
-      overall: 0.75,
-      predictions: Array.from(this.metrics.values())
+      overall: Math.round(overall * 100) / 100,
+      predictions: values
     };
   }
 }

--- a/src/db/EnhancedVectorDatabase.ts
+++ b/src/db/EnhancedVectorDatabase.ts
@@ -1,4 +1,5 @@
 import { CONSTANTS } from '../utils/constants';
+import patchPrompts from '../../docs/Patch_Discovery_RAG_System_Prompts.md?raw';
 
 export class EnhancedVectorDatabase {
   constructor() {
@@ -195,6 +196,15 @@ export class EnhancedVectorDatabase {
         category: item.category,
         tags: item.tags,
         source: 'cve-knowledge-base'
+      });
+    }
+
+    if (patchPrompts) {
+      await this.addDocument(patchPrompts, {
+        title: 'Patch Discovery System Prompts',
+        category: 'prompt-engineering',
+        tags: ['patch', 'rag', 'prompt'],
+        source: 'internal-docs'
       });
     }
   }


### PR DESCRIPTION
## Summary
- refine continuous learning accuracy calculations
- report aggregated accuracy metrics
- load patch discovery prompts into the RAG knowledge base

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68826c578dec832c8957c0eae0e90f1a