### PR TITLE
Add RL triage and attack graph utilities

### DIFF
--- a/src/analysis/AttackGraph.test.ts
+++ b/src/analysis/AttackGraph.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { AttackGraph } from './AttackGraph';
+
+describe('AttackGraph', () => {
+  it('calculates path risk', () => {
+    const g = new AttackGraph();
+    g.addNode({ id: 'A', assetValue: 2 });
+    g.addNode({ id: 'B', assetValue: 3 });
+    g.addNode({ id: 'C', assetValue: 1 });
+    g.addEdge({ from: 'A', to: 'B', vulnerability: 'CVE-1', technique: 'T1000', risk: 5 });
+    g.addEdge({ from: 'B', to: 'C', vulnerability: 'CVE-2', technique: 'T2000', risk: 4 });
+    const risk = g.getPathRisk('A', 'C');
+    expect(risk).toBe(2 + 5 + 3 + 4 + 1); // sum of node values and edge risks
+  });
+});

--- a/src/analysis/AttackGraph.ts
+++ b/src/analysis/AttackGraph.ts
@@ -1,0 +1,50 @@
+export interface AttackNode {
+  id: string;
+  assetValue: number;
+}
+
+export interface AttackEdge {
+  from: string;
+  to: string;
+  vulnerability: string; // CVE id
+  technique?: string; // MITRE ATT&CK technique id
+  risk: number; // computed risk weight
+}
+
+export class AttackGraph {
+  private nodes: Map<string, AttackNode> = new Map();
+  private edges: AttackEdge[] = [];
+
+  addNode(node: AttackNode) {
+    this.nodes.set(node.id, node);
+  }
+
+  addEdge(edge: AttackEdge) {
+    if (!this.nodes.has(edge.from) || !this.nodes.has(edge.to)) {
+      throw new Error('Both nodes must exist');
+    }
+    this.edges.push(edge);
+  }
+
+  getPathRisk(start: string, end: string): number {
+    const visited = new Set<string>();
+    let minRisk = Infinity;
+
+    const dfs = (current: string, risk: number) => {
+      if (current === end) {
+        minRisk = Math.min(minRisk, risk);
+        return;
+      }
+      visited.add(current);
+      for (const edge of this.edges) {
+        if (edge.from === current && !visited.has(edge.to)) {
+          dfs(edge.to, risk + edge.risk + (this.nodes.get(edge.to)?.assetValue || 0));
+        }
+      }
+      visited.delete(current);
+    };
+
+    dfs(start, this.nodes.get(start)?.assetValue || 0);
+    return minRisk === Infinity ? 0 : minRisk;
+  }
+}

--- a/src/analysis/ExploitTrendPredictor.ts
+++ b/src/analysis/ExploitTrendPredictor.ts
@@ -1,0 +1,11 @@
+export function predictExploitProbability(cvss: number, daysSinceDisclosure: number): number {
+  const k = 0.1 * cvss; // influence of cvss on growth rate
+  const x0 = 30; // midpoint in days
+  const prob = 1 / (1 + Math.exp(-k * (daysSinceDisclosure - x0)));
+  return Math.min(1, Math.max(0, prob));
+}
+
+export function predictDaysToExploit(cvss: number): number {
+  const base = 60 - cvss * 4; // higher cvss => faster exploit
+  return Math.max(1, base);
+}

--- a/src/analysis/RLTriageAgent.test.ts
+++ b/src/analysis/RLTriageAgent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { RLTriageAgent } from './RLTriageAgent';
+import { VulnerabilityContext } from './VulnerabilityRanking';
+
+describe('RLTriageAgent', () => {
+  it('updates weights based on reward', () => {
+    const agent = new RLTriageAgent();
+    const ctx: VulnerabilityContext = {
+      assetValue: 5,
+      exploitability: 5,
+      lateralMovement: 5,
+      activeExploitation: false
+    };
+    const before = agent.score(ctx);
+    agent.update(ctx, before + 10); // positive reward
+    const after = agent.score(ctx);
+    expect(after).toBeGreaterThan(before);
+  });
+});

--- a/src/analysis/RLTriageAgent.ts
+++ b/src/analysis/RLTriageAgent.ts
@@ -1,0 +1,25 @@
+import { RankingWeights, VulnerabilityContext, defaultWeights, calculateVulnerabilityScore } from './VulnerabilityRanking';
+
+export class RLTriageAgent {
+  private weights: RankingWeights = { ...defaultWeights };
+  private learningRate = 0.01;
+
+  score(context: VulnerabilityContext): number {
+    return calculateVulnerabilityScore(context, this.weights);
+  }
+
+  update(context: VulnerabilityContext, reward: number) {
+    const prediction = this.score(context);
+    const error = reward - prediction;
+    this.weights.assetValue += this.learningRate * error * context.assetValue;
+    this.weights.exploitability += this.learningRate * error * context.exploitability;
+    this.weights.lateralMovement += this.learningRate * error * context.lateralMovement;
+    if (context.activeExploitation) {
+      this.weights.activeExploitation += this.learningRate * error * 10;
+    }
+  }
+
+  getWeights(): RankingWeights {
+    return { ...this.weights };
+  }
+}

--- a/src/analysis/VulnerabilityRanking.test.ts
+++ b/src/analysis/VulnerabilityRanking.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { calculateVulnerabilityScore, VulnerabilityContext } from './VulnerabilityRanking';
+
+describe('calculateVulnerabilityScore', () => {
+  it('computes score with default weights', () => {
+    const ctx: VulnerabilityContext = {
+      assetValue: 5,
+      exploitability: 7,
+      lateralMovement: 3,
+      activeExploitation: true
+    };
+    const score = calculateVulnerabilityScore(ctx);
+    expect(score).toBe(5 + 7 + 3 + 20); // active exploitation adds 20
+  });
+});

--- a/src/analysis/VulnerabilityRanking.ts
+++ b/src/analysis/VulnerabilityRanking.ts
@@ -1,0 +1,32 @@
+export interface VulnerabilityContext {
+  assetValue: number; // 0-10 importance of the affected asset
+  exploitability: number; // 0-10 likelihood of exploit
+  lateralMovement: number; // 0-10 potential for lateral movement
+  activeExploitation: boolean; // currently being exploited
+}
+
+export interface RankingWeights {
+  assetValue: number;
+  exploitability: number;
+  lateralMovement: number;
+  activeExploitation: number;
+}
+
+export const defaultWeights: RankingWeights = {
+  assetValue: 1,
+  exploitability: 1,
+  lateralMovement: 1,
+  activeExploitation: 2
+};
+
+export function calculateVulnerabilityScore(
+  context: VulnerabilityContext,
+  weights: RankingWeights = defaultWeights
+): number {
+  const score =
+    context.assetValue * weights.assetValue +
+    context.exploitability * weights.exploitability +
+    context.lateralMovement * weights.lateralMovement +
+    (context.activeExploitation ? weights.activeExploitation * 10 : 0);
+  return score;
+}

--- a/src/analysis/index.ts
+++ b/src/analysis/index.ts
@@ -1,3 +1,7 @@
 export * from './TaintAnalyzer';
 export * from './CVEMapping';
 export * from './ReportGenerator';
+export * from './VulnerabilityRanking';
+export * from './RLTriageAgent';
+export * from './AttackGraph';
+export * from './ExploitTrendPredictor';


### PR DESCRIPTION
## Summary
- implement vulnerability ranking utilities
- add reinforcement learning triage agent
- create simple attack graph model
- add exploit trend prediction helper
- export new analysis modules
- test new functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68849cd12dc8832cb99049c892dfca70