### PR TITLE
Fix dev server command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ cd vulnerability-intelligence-platform
 npm install
 
 # Start development server
-npm start
+npm run dev
 ```
 
 ### **🔑 API Configuration**


### PR DESCRIPTION
## Summary
- correct README docs to run the Vite dev server using `npm run dev`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884ac270448832cb3844902775b8d29