### PR TITLE
Switch default model to gpt‑4.1

### DIFF
--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -396,7 +396,7 @@ export class CybersecurityAgent {
               Authorization: `Bearer ${this.settings.openAiApiKey}`
             },
             body: JSON.stringify({
-              model: 'gpt-4o',
+              model: 'gpt-4.1',
               messages: [{ role: 'user', content: query }],
               max_tokens: 4096
             })

--- a/src/agents/ResearchAgent.ts
+++ b/src/agents/ResearchAgent.ts
@@ -602,7 +602,7 @@ export class SmartResearchAgent {
         geminiApiKey: apiKeys.geminiApiKey || enhancedSettings.geminiApiKey,
         geminiModel: aiModel.model,
         openAiApiKey: enhancedSettings.openAiApiKey,
-        openAiModel: enhancedSettings.openAiModel || 'gpt-4o'
+        openAiModel: enhancedSettings.openAiModel || 'gpt-4.1'
       };
 
       // Fetch primary data with parallel optimization

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -2860,7 +2860,7 @@ export class UserAssistantAgent {
                   Authorization: `Bearer ${this.settings.openAiApiKey}`
                 },
                 body: JSON.stringify({
-                  model: 'gpt-4o',
+                  model: 'gpt-4.1',
                   messages: [{ role: 'user', content: query }],
                   max_tokens: 4096
                 })

--- a/src/components/SearchComponent.tsx
+++ b/src/components/SearchComponent.tsx
@@ -40,7 +40,7 @@ const SearchComponent = () => {
         geminiApiKey: settings.geminiApiKey,
         geminiModel: settings.geminiModel || 'gemini-1.5-flash',
         openAiApiKey: settings.openAiApiKey,
-        openAiModel: settings.openAiModel || 'gpt-4o'
+        openAiModel: settings.openAiModel || 'gpt-4.1'
       });
       console.log('🤖 AI settings initialized for web search fallbacks');
     } else {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -152,10 +152,10 @@ const SettingsModal = ({ isOpen, onClose }) => {
             </label>
             <select
               style={styles.input}
-              value={localSettings.openAiModel || 'gpt-4o'}
+              value={localSettings.openAiModel || 'gpt-4.1'}
               onChange={(e) => setLocalSettings(prev => ({ ...prev, openAiModel: e.target.value }))}
             >
-              <option value="gpt-4o">GPT-4o</option>
+              <option value="gpt-4.1">GPT-4.1</option>
             </select>
           </div>
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -7,7 +7,7 @@ export const useSettings = () => {
     geminiModel: 'gemini-2.5-flash',
     nvdApiKey: '',
     openAiApiKey: '',
-    openAiModel: 'gpt-4o',
+    openAiModel: 'gpt-4.1',
     enableRAG: true
   });
 

--- a/src/services/AIEnhancementService.test.ts
+++ b/src/services/AIEnhancementService.test.ts
@@ -4,16 +4,24 @@ import { fetchGeneralAnswer, parseDescriptionBasedResponse } from './AIEnhanceme
 // Simple mock response for OpenAI
 const mockResponse = {
   ok: true,
-  json: () => Promise.resolve({ choices: [{ message: { content: 'ok' } }] })
+  json: () =>
+    Promise.resolve({
+      output: [
+        {
+          type: 'message',
+          content: [{ type: 'output_text', text: 'ok' }]
+        }
+      ]
+    })
 } as any;
 
 describe('fetchGeneralAnswer', () => {
   it('includes web search tool when using OpenAI', async () => {
     const fetcher = vi.fn().mockResolvedValue(mockResponse);
-    await fetchGeneralAnswer('hi', { openAiApiKey: 'key', openAiModel: 'gpt-4o' }, fetcher);
+    await fetchGeneralAnswer('hi', { openAiApiKey: 'key', openAiModel: 'gpt-4.1' }, fetcher);
     const options = fetcher.mock.calls[0][1];
     const body = JSON.parse(options.body);
-    expect(body.tools).toEqual([{ type: 'function', function: { name: 'web_search' } }]);
+    expect(body.tools).toEqual([{ type: 'web_search_preview' }]);
   });
 });
 

--- a/src/services/AIEnhancementService.ts
+++ b/src/services/AIEnhancementService.ts
@@ -107,7 +107,7 @@ export async function fetchPatchesAndAdvisories(
   }
 
   const useGemini = !settings.openAiApiKey && !!settings.geminiApiKey;
-  const model = useGemini ? (settings.geminiModel || 'gemini-2.5-flash') : (settings.openAiModel || 'gpt-4o');
+  const model = useGemini ? (settings.geminiModel || 'gemini-2.5-flash') : (settings.openAiModel || 'gpt-4.1');
   const geminiSearchCapable = useGemini && (model.includes('2.0') || model.includes('2.5'));
   
   // OpenAI /responses endpoint DOES exist and supports web search
@@ -129,7 +129,7 @@ export async function fetchPatchesAndAdvisories(
   }
 
   if (!useGemini && !openAiSearchCapable) {
-    updateSteps(prev => [...prev, `⚠️ Web search not supported by OpenAI model - use gpt-4.1 or gpt-4o`]);
+    updateSteps(prev => [...prev, `⚠️ Web search not supported by OpenAI model - use gpt-4.1`]);
     return getHeuristicPatchesAndAdvisories(cveId, cveData);
   }
 
@@ -370,7 +370,7 @@ export async function fetchAIThreatIntelligence(
   }
 
   const useGemini = !!settings.geminiApiKey;
-  const model = useGemini ? (settings.geminiModel || 'gemini-2.5-flash') : (settings.openAiModel || 'gpt-4o');
+  const model = useGemini ? (settings.geminiModel || 'gemini-2.5-flash') : (settings.openAiModel || 'gpt-4.1');
   const geminiSearchCapable = useGemini && (model.includes('2.0') || model.includes('2.5'));
   // Re-enable OpenAI web search - /responses endpoint is available
   const openAiSearchCapable = !useGemini && model === 'gpt-4.1';
@@ -820,7 +820,7 @@ export async function fetchGeneralAnswer(query: string, settings: any, fetchWith
   }
   
   const useGemini = !!settings.geminiApiKey;
-  const model = useGemini ? (settings.geminiModel || "gemini-2.5-flash") : (settings.openAiModel || 'gpt-4o');
+  const model = useGemini ? (settings.geminiModel || "gemini-2.5-flash") : (settings.openAiModel || 'gpt-4.1');
   const geminiSearchCapable = useGemini && (model.includes('2.0') || model.includes('2.5'));
   // Re-enable OpenAI web search
   const openAiSearchCapable = !useGemini && model === 'gpt-4.1';
@@ -966,7 +966,7 @@ export async function generateAITaintAnalysis(
         }
       : {
           // Standard chat completions format (fallback)
-          model: settings.openAiModel || 'gpt-4o',
+          model: settings.openAiModel || 'gpt-4.1',
           messages: [{ 
             role: 'user', 
             content: prompt 

--- a/src/services/DataFetchingService.ts
+++ b/src/services/DataFetchingService.ts
@@ -39,7 +39,7 @@ async function fetchWithAIWebSearch(url: string, aiSettings: any, specificQuery?
   }
   
   const useGemini = !!activeSettings.geminiApiKey;
-  const model = useGemini ? (activeSettings.geminiModel || 'gemini-2.5-flash') : (activeSettings.openAiModel || 'gpt-4o');
+  const model = useGemini ? (activeSettings.geminiModel || 'gemini-2.5-flash') : (activeSettings.openAiModel || 'gpt-4.1');
   
   // FORCE OpenAI web search for all OpenAI requests
   const openAiSearchCapable = !useGemini; // Always true for OpenAI


### PR DESCRIPTION
## Summary
- default to `gpt-4.1` in settings and services
- update Settings modal and search component defaults
- adjust agents to use `gpt-4.1`
- update AI enhancement service and tests for new responses format

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884adec0988832c9925ad4d18b3a435