### PR TITLE
Fix AI status color for OpenAI key

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,25 +170,31 @@ const App = () => {
             </div>
             
             <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-              <div style={{
-                ...styles.badge,
-                background: settings.geminiApiKey
-                  ? (settings.darkMode ? `rgba(${utils.hexToRgb(COLORS.green)}, 0.15)` : `rgba(${utils.hexToRgb(COLORS.green)}, 0.1)`)
-                  : (settings.darkMode ? `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.15)` : `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.1)`),
-                borderColor: settings.geminiApiKey
-                  ? `rgba(${utils.hexToRgb(COLORS.green)}, 0.3)`
-                  : `rgba(${utils.hexToRgb(COLORS.yellow)}, 0.3)`,
-                color: settings.geminiApiKey ? COLORS.green : COLORS.yellow,
-                borderWidth: '1px',
-                borderStyle: 'solid',
-                fontWeight: '600',
-                fontSize: '0.875rem',
-                padding: '8px 14px',
-                minHeight: '44px',
-              }}>
-                <Brain size={16} />
-                {settings.geminiApiKey || settings.openAiApiKey ? 'AI Ready' : 'AI Offline'}
-              </div>
+              {(() => {
+                const aiActive = settings.geminiApiKey || settings.openAiApiKey;
+                const badgeColor = aiActive ? COLORS.green : COLORS.yellow;
+                return (
+                  <div
+                    style={{
+                      ...styles.badge,
+                      background: settings.darkMode
+                        ? `rgba(${utils.hexToRgb(badgeColor)}, 0.15)`
+                        : `rgba(${utils.hexToRgb(badgeColor)}, 0.1)`,
+                      borderColor: `rgba(${utils.hexToRgb(badgeColor)}, 0.3)`,
+                      color: badgeColor,
+                      borderWidth: '1px',
+                      borderStyle: 'solid',
+                      fontWeight: '600',
+                      fontSize: '0.875rem',
+                      padding: '8px 14px',
+                      minHeight: '44px',
+                    }}
+                  >
+                    <Brain size={16} />
+                    {aiActive ? 'AI Ready' : 'AI Offline'}
+                  </div>
+                );
+              })()}
               
               <button
                 onClick={() => setShowSettings(true)}

--- a/src/components/SearchComponent.tsx
+++ b/src/components/SearchComponent.tsx
@@ -255,18 +255,18 @@ const SearchComponent = () => {
           <div style={{
             marginTop: '24px',
             padding: '12px 16px',
-            background: `rgba(${utils.hexToRgb(COLORS.blue)}, 0.1)`,
+            background: `rgba(${utils.hexToRgb(COLORS.green)}, 0.1)`,
             borderRadius: '8px',
-            border: `1px solid rgba(${utils.hexToRgb(COLORS.blue)}, 0.2)`,
+            border: `1px solid rgba(${utils.hexToRgb(COLORS.green)}, 0.2)`,
             display: 'inline-flex',
             alignItems: 'center',
             gap: '8px',
             fontSize: '0.875rem',
-            color: COLORS.blue,
+            color: COLORS.green,
             fontWeight: '500'
           }}>
             <Brain size={16} />
-            OpenAI Analysis Mode - No Web Search
+            OpenAI Analysis Mode - Web Search
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- show OpenAI analysis mode as `Web Search` with a green badge
- mark "AI Ready" badge green when either API key is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884cb588c04832cbb4f54e0493cb6fe