### PR TITLE
Add tests for API and data fetching services

### DIFF
--- a/src/services/APIService.test.ts
+++ b/src/services/APIService.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('./AIEnhancementService', () => ({
+  fetchPatchesAndAdvisories: vi.fn(),
+  fetchAIThreatIntelligence: vi.fn(),
+  generateAIAnalysis: vi.fn(),
+  generateAITaintAnalysis: vi.fn(),
+  fetchGeneralAnswer: vi.fn()
+}))
+
+import { APIService } from './APIService'
+import * as AI from './AIEnhancementService'
+
+const dummySettings = { openAiApiKey: 'k', openAiModel: 'gpt-4.1' }
+
+describe('APIService.fetchPatchesAndAdvisories', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('caches successful responses', async () => {
+    const mock = vi
+      .spyOn(AI, 'fetchPatchesAndAdvisories')
+      .mockResolvedValue({ patches: ['p1'], advisories: ['a1'], searchSummary: {} })
+
+    const res1 = await APIService.fetchPatchesAndAdvisories('CVE-1111', {}, dummySettings, () => {})
+    const res2 = await APIService.fetchPatchesAndAdvisories('CVE-1111', {}, dummySettings, () => {})
+
+    expect(mock).toHaveBeenCalledTimes(1)
+    expect(res1).toEqual(res2)
+  })
+
+  it('does not cache failed requests', async () => {
+    const mock = vi
+      .spyOn(AI, 'fetchPatchesAndAdvisories')
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({ patches: [], advisories: [], searchSummary: {} })
+
+    await expect(
+      APIService.fetchPatchesAndAdvisories('CVE-2222', {}, dummySettings, () => {})
+    ).rejects.toThrow('fail')
+
+    const res = await APIService.fetchPatchesAndAdvisories('CVE-2222', {}, dummySettings, () => {})
+    expect(mock).toHaveBeenCalledTimes(2)
+    expect(res.patches).toEqual([])
+  })
+})

--- a/src/services/DataFetchingService.test.ts
+++ b/src/services/DataFetchingService.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import * as DFS from './DataFetchingService'
+
+const sampleNvd = {
+  vulnerabilities: [
+    {
+      cve: {
+        id: 'CVE-TEST',
+        descriptions: [{ lang: 'en', value: 'desc' }],
+        published: '2024-01-01',
+        lastModified: '2024-01-02',
+        metrics: {
+          cvssMetricV31: [
+            { cvssData: { baseScore: 7.2, baseSeverity: 'HIGH', vectorString: 'V' } }
+          ]
+        },
+        references: [],
+        configurations: [],
+        weaknesses: []
+      }
+    }
+  ]
+}
+
+describe('fetchCVEData', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses direct API when no AI settings', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(sampleNvd) })
+    global.fetch = fetchMock as any
+
+    const res = await DFS.fetchCVEData('CVE-TEST', null, () => {}, null)
+    expect(fetchMock).toHaveBeenCalled()
+    expect(res.id).toBe('CVE-TEST')
+  })
+
+  it('handles AI search path', async () => {
+    const aiResponse = {
+      output: [
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text:
+                'Description: Something. CVSS 7.3 (HIGH). 2024-01-01 2024-02-01'
+            }
+          ]
+        }
+      ]
+    }
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      json: () => Promise.resolve(aiResponse),
+      text: () => Promise.resolve(JSON.stringify(aiResponse))
+    })
+    global.fetch = fetchMock as any
+
+    const rag = { initialized: true, addDocument: vi.fn() }
+    const res = await DFS.fetchCVEData('CVE-XYZ', null, () => {}, rag, {
+      openAiApiKey: 'k'
+    })
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(res.aiEnhanced).toBe(true)
+    expect(res.id).toBe('CVE-XYZ')
+    expect(rag.addDocument).toHaveBeenCalled()
+  })
+
+  it('throws when direct API fails and no AI', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 })
+    await expect(DFS.fetchCVEData('CVE-BAD', null, () => {}, null)).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for APIService caching
- add unit tests for DataFetchingService fallback logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884cffd7614832cb7822fb6f4a56d6e