### PR TITLE
Fix duplicated search in CybersecurityAgent

### DIFF
--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CybersecurityAgent } from '../agents/CybersecurityAgent';
+
+const groundedResult = { content: 'grounded', sources: [], confidence: 0.9 };
+
+describe('CybersecurityAgent', () => {
+  it('calls groundingEngine.search only once', async () => {
+    const agent = new CybersecurityAgent();
+    const searchSpy = vi
+      .fn()
+      .mockResolvedValue(groundedResult);
+    (agent as any).groundingEngine = { search: searchSpy };
+
+    const result = await agent.handleQuery('tell me something');
+
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe(groundedResult.content);
+  });
+});

--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -163,14 +163,12 @@ export class CybersecurityAgent {
       if (this.groundingEngine) {
         const grounded = await this.groundingEngine.search(query);
         if (grounded.content) {
-          return { text: grounded.content, sender: 'bot', id: Date.now().toString(), confidence: grounded.confidence };
-        }
-      }
-
-      if (this.groundingEngine) {
-        const grounded = await this.groundingEngine.search(query);
-        if (grounded.content) {
-          return { text: grounded.content, sender: 'bot', id: Date.now().toString(), confidence: grounded.confidence };
+          return {
+            text: grounded.content,
+            sender: 'bot',
+            id: Date.now().toString(),
+            confidence: grounded.confidence,
+          };
         }
       }
 


### PR DESCRIPTION
## Summary
- remove duplicate `groundingEngine.search` call
- add unit test for single search invocation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884d4d6667c832cab1fe7f84911da15