### PR TITLE
Add RAG integration to CybersecurityAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Risk Score = f(CVSS, EPSS, KEV_Status, Threat_Intelligence, Business_Impact)
 ### **🧩 Agents Overview**
 Our analysis workflow is composed of several cooperating agents:
 - **ResearchAgent** – gathers vulnerability intelligence and performs AI-driven searches.
+- **CybersecurityAgent** – answers questions using the RAG knowledge base before searching the web.
 - **RAGCuratorAgent** – keeps the vector database fresh by re-analyzing stale summaries.
 - **ValidationAgent** – validates AI findings against trusted sources and stores the results.
 - **UserAssistantAgent** – conversational interface used by the chatbot and UI components.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,14 @@ export default [
     },
   },
   {
+    files: ['server/*.js'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.node,
+      sourceType: 'module',
+    },
+  },
+  {
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CybersecurityAgent } from './CybersecurityAgent';
+import { ragDatabase } from '../db/EnhancedVectorDatabase';
+
+describe('CybersecurityAgent', () => {
+  it('handleQuery returns RAG result when available', async () => {
+    const agent = new CybersecurityAgent();
+    ragDatabase.initialized = true;
+    const searchSpy = vi
+      .spyOn(ragDatabase, 'search')
+      .mockResolvedValue([{ content: 'RAG info', similarity: 0.9 }] as any);
+    const ensureSpy = vi
+      .spyOn(ragDatabase, 'ensureInitialized')
+      .mockResolvedValue();
+    const res = await agent.handleQuery('CVE-2020-1234');
+    expect(searchSpy).toHaveBeenCalled();
+    expect(res.text).toContain('RAG info');
+    searchSpy.mockRestore();
+    ensureSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- mention CybersecurityAgent in README
- allow server files to lint as Node
- search RAG before web search in CybersecurityAgent
- store generated reports in RAG
- test CybersecurityAgent RAG behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884d4c0dffc832c8758d0665220132a