### PR TITLE
Enable auto-learning in CybersecurityAgent

### DIFF
--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -16,4 +16,16 @@ describe('CybersecurityAgent', () => {
     expect(searchSpy).toHaveBeenCalledTimes(1);
     expect(result.text).toBe(groundedResult.content);
   });
+
+  it('calls groundingEngine.learn when autoLearn is enabled', async () => {
+    const agent = new CybersecurityAgent();
+    const searchSpy = vi.fn().mockResolvedValue(groundedResult);
+    const learnSpy = vi.fn();
+    (agent as any).groundingEngine = { search: searchSpy, learn: learnSpy };
+    (agent as any).groundingConfig = { autoLearn: true };
+
+    await (agent as any).getGroundedInfo('example');
+
+    expect(learnSpy).toHaveBeenCalledWith(groundedResult);
+  });
 });

--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -249,6 +249,9 @@ export class CybersecurityAgent {
       return { content: '', sources: [], confidence: 0 };
     }
     const result = await this.groundingEngine.search(query);
+    if (this.groundingConfig?.autoLearn) {
+      await this.groundingEngine.learn(result);
+    }
     return result;
   }
 


### PR DESCRIPTION
## Summary
- add auto-learning call in `CybersecurityAgent` when grounding information is fetched
- test that autoLearn triggers the learn method

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884d64e3ec0832c98088ae0e3b61c06