### PR TITLE
Fix frontend to use backend AI proxy

### DIFF
--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -66,7 +66,7 @@ export class AIGroundingEngine {
     if (this.keys.gemini) {
       try {
         const res = await fetch(
-          `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${this.keys.gemini}`,
+          `/api/gemini?model=gemini-2.5-flash`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -90,11 +90,10 @@ export class AIGroundingEngine {
     // OpenAI search
     if (this.keys.openai) {
       try {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        const res = await fetch('/api/openai?endpoint=chat/completions', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.keys.openai}`
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({
             model: 'gpt-4.1',
@@ -363,7 +362,7 @@ export class CybersecurityAgent {
 
       const searchPrompt = `Search for information about: ${query}. Provide a comprehensive analysis including current threat status, patches, advisories, and any dispute information.`;
 
-      const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${this.settings.geminiApiKey}`, {
+      const response = await fetch(`/api/gemini?model=gemini-2.5-flash`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -390,11 +389,10 @@ export class CybersecurityAgent {
 
       if (this.settings.openAiApiKey) {
         try {
-          const openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+          const openaiRes = await fetch('/api/openai?endpoint=chat/completions', {
             method: 'POST',
             headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.settings.openAiApiKey}`
+              'Content-Type': 'application/json'
             },
             body: JSON.stringify({
               model: 'gpt-4.1',

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -66,7 +66,7 @@ export class AIGroundingEngine {
     if (this.keys.gemini) {
       try {
         const res = await fetch(
-          `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${this.keys.gemini}`,
+          `/api/gemini?model=gemini-2.5-flash`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -90,11 +90,10 @@ export class AIGroundingEngine {
     // OpenAI search
     if (this.keys.openai) {
       try {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        const res = await fetch('/api/openai?endpoint=chat/completions', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${this.keys.openai}`
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({
             model: 'gpt-4.1',
@@ -2821,7 +2820,7 @@ export class UserAssistantAgent {
       // Retry logic for API failures
       for (let attempt = 1; attempt <= 3; attempt++) {
         try {
-          const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${this.settings.geminiApiKey}`, {
+          const response = await fetch(`/api/gemini?model=gemini-2.5-flash`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -2853,11 +2852,10 @@ export class UserAssistantAgent {
 
           if (this.settings.openAiApiKey) {
             try {
-              const openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+              const openaiRes = await fetch('/api/openai?endpoint=chat/completions', {
                 method: 'POST',
                 headers: {
-                  'Content-Type': 'application/json',
-                  Authorization: `Bearer ${this.settings.openAiApiKey}`
+                  'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
                   model: 'gpt-4.1',

--- a/src/db/EnhancedVectorDatabase.ts
+++ b/src/db/EnhancedVectorDatabase.ts
@@ -25,7 +25,7 @@ export class EnhancedVectorDatabase {
   }
 
   async createGeminiEmbedding(text) {
-    const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-exp-03-07:embedContent';
+    const url = '/api/gemini?model=gemini-embedding-exp-03-07&action=embedContent';
     const requestBody = {
       model: "models/gemini-embedding-exp-03-07",
       content: {
@@ -38,7 +38,6 @@ export class EnhancedVectorDatabase {
       response = await fetch(url, {
         method: 'POST',
         headers: {
-          'x-goog-api-key': this.geminiApiKey,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(requestBody)

--- a/src/services/GeminiRateLimiter.ts
+++ b/src/services/GeminiRateLimiter.ts
@@ -157,7 +157,7 @@ export async function fetchWithAIWebSearchEnhanced(
       }]
     };
     
-    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${settings.geminiApiKey}`;
+    const apiUrl = `/api/gemini?model=${model}`;
     
     try {
       const data = await fetchWithGeminiRateLimit(apiUrl, requestBody, settings.geminiApiKey);


### PR DESCRIPTION
## Summary
- route OpenAI and Gemini requests through the local `/api` endpoints
- remove API keys from frontend requests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885bebf5a44832cbe26b9683a5b7e5c