### PR TITLE
Fix dev API routing

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,11 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- configure Vite dev server to proxy `/api` to the Express backend

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c486e3c0832c976e2a12c02df85f