### PR TITLE
Add Cybersecurity Agent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,16 @@ OPENAI_USER_LOCATION=us OPENAI_SEARCH_CONTEXT_SIZE=5 \
 node scripts/ai-web-search.js "what was a positive news story from today?"
 ```
 
+### 🖥️ Cybersecurity Agent CLI
+Chat with the agent directly from your terminal. The script uses API keys from
+your `.env` file.
+
+```bash
+npx ts-node scripts/cybersecurity-agent-cli.ts
+```
+
+Type a question like `"tell me about CVE-2024-1234"` and enter `exit` to quit.
+
 ### **🗣️ Smart Assistant Commands**
 ```
 /help             - List available assistant commands

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "server": "node server/index.js",
     "start": "concurrently \"npm run server\" \"npm run dev\"",
-    "curate": "ts-node scripts/curation-cycle.ts"
+    "curate": "ts-node scripts/curation-cycle.ts",
+    "cybersecurity-cli": "ts-node scripts/cybersecurity-agent-cli.ts"
   },
   "dependencies": {
     "dotenv": "^17.2.1",

--- a/scripts/cybersecurity-agent-cli.ts
+++ b/scripts/cybersecurity-agent-cli.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env ts-node
+import { fileURLToPath } from 'url';
+import path from 'path';
+import readline from 'readline';
+import dotenv from 'dotenv';
+import { CybersecurityAgent } from '../src/agents/CybersecurityAgent';
+import { AgentSettings } from '../src/types/cveData';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+const settings: AgentSettings = {
+  openAiApiKey: process.env.OPENAI_API_KEY,
+  geminiApiKey: process.env.GEMINI_API_KEY,
+  nvdApiKey: process.env.NVD_API_KEY,
+};
+
+const agent = new CybersecurityAgent(settings);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: '> '
+});
+
+console.log('Cybersecurity Agent CLI. Type "exit" to quit.');
+rl.prompt();
+
+rl.on('line', async line => {
+  const input = line.trim();
+  if (input.toLowerCase() === 'exit') {
+    rl.close();
+    return;
+  }
+  try {
+    const res = await agent.handleQuery(input);
+    console.log(res.text);
+  } catch (err: any) {
+    console.error('Error:', err.message);
+  }
+  rl.prompt();
+});
+
+rl.on('close', () => {
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- add a simple command-line interface script for interacting with the CybersecurityAgent
- expose new `cybersecurity-cli` npm script
- document CLI usage in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688749ef73fc832c82899644a6b2570e