### PR TITLE
Improve RAG handling for security queries

### DIFF
--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -4,14 +4,15 @@ import { CybersecurityAgent } from '../agents/CybersecurityAgent';
 const groundedResult = { content: 'grounded', sources: [], confidence: 0.9 };
 
 describe('CybersecurityAgent', () => {
-  it('calls groundingEngine.search only once', async () => {
+  it('calls groundingEngine.search only once for security query', async () => {
     const agent = new CybersecurityAgent();
     const searchSpy = vi
       .fn()
       .mockResolvedValue(groundedResult);
-    (agent as any).groundingEngine = { search: searchSpy };
+    const learnSpy = vi.fn();
+    (agent as any).groundingEngine = { search: searchSpy, learn: learnSpy };
 
-    const result = await agent.handleQuery('tell me something');
+    const result = await agent.handleQuery('explain vulnerability trends');
 
     expect(searchSpy).toHaveBeenCalledTimes(1);
     expect(result.text).toBe(groundedResult.content);

--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -149,12 +149,29 @@ export class CybersecurityAgent {
     this.cacheTTL = this.settings.cacheTTL ?? this.DEFAULT_CACHE_TTL;
 
     if (this.settings.openAiApiKey || this.settings.geminiApiKey) {
-      this.groundingConfig = { enableWebGrounding: true };
+      this.groundingConfig = { enableWebGrounding: true, autoLearn: true };
       this.groundingEngine = new AIGroundingEngine(this.groundingConfig, {
         gemini: this.settings.geminiApiKey,
         openai: this.settings.openAiApiKey,
       });
     }
+  }
+
+  private isCybersecurityRelated(query: string): boolean {
+    const keywords = [
+      'cve',
+      'vulnerability',
+      'exploit',
+      'patch',
+      'malware',
+      'cyber',
+      'security',
+      'kev',
+      'epss',
+      'threat'
+    ];
+    const lower = query.toLowerCase();
+    return keywords.some(k => lower.includes(k));
   }
 
   public async handleQuery(query: string): Promise<ChatResponse> {
@@ -182,8 +199,8 @@ export class CybersecurityAgent {
         return res;
       }
 
-      if (this.groundingEngine) {
-        const grounded = await this.groundingEngine.search(query);
+      if (this.groundingEngine && this.isCybersecurityRelated(query)) {
+        const grounded = await this.getGroundedInfo(query);
         if (grounded.content) {
           return {
             text: grounded.content,


### PR DESCRIPTION
## Summary
- automatically store grounded search results using RAG
- detect security-related queries and only fetch web results for those
- update tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68875cd484bc832ca5f20b5cf7e10c3a