### PR TITLE
Prioritize OpenAI provider

### DIFF
--- a/scripts/ai-web-search.js
+++ b/scripts/ai-web-search.js
@@ -12,35 +12,12 @@ if (!geminiKey && !openaiKey) {
   process.exit(1)
 }
 
-const useGemini = !!geminiKey
+const useOpenAI = !!openaiKey
+const useGemini = !useOpenAI && !!geminiKey
 
 async function run() {
   try {
-    if (useGemini) {
-      const body = {
-        contents: [{ parts: [{ text: query }] }],
-        generationConfig: {
-          temperature: 0.3,
-          topK: 1,
-          topP: 0.8,
-          maxOutputTokens: 1024,
-          candidateCount: 1
-        },
-        tools: [{ google_search: {} }]
-      }
-      const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiKey}`
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      })
-      if (!response.ok) {
-        throw new Error(`Gemini API error: ${response.status}`)
-      }
-      const data = await response.json()
-      const text = data.candidates?.[0]?.content?.parts?.[0]?.text
-      console.log(text || JSON.stringify(data, null, 2))
-    } else {
+    if (useOpenAI) {
       const body = {
         model: 'gpt-4.1',
         tools: [{ type: 'web_search_preview' }],
@@ -87,6 +64,30 @@ async function run() {
           console.log('\nCitation URLs:\n' + urls.join('\n'))
         }
       }
+    } else if (useGemini) {
+      const body = {
+        contents: [{ parts: [{ text: query }] }],
+        generationConfig: {
+          temperature: 0.3,
+          topK: 1,
+          topP: 0.8,
+          maxOutputTokens: 1024,
+          candidateCount: 1
+        },
+        tools: [{ google_search: {} }]
+      }
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${geminiKey}`
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+      if (!response.ok) {
+        throw new Error(`Gemini API error: ${response.status}`)
+      }
+      const data = await response.json()
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text
+      console.log(text || JSON.stringify(data, null, 2))
     }
   } catch (err) {
     console.error('Request failed:', err.message)


### PR DESCRIPTION
## Summary
- prefer OpenAI when an OpenAI key is present
- improve web search fallback logic in cybersecurity and user assistant agents
- update CLI web search script to default to OpenAI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688765e46940832cb6f4046be3d2c3dc