### PR TITLE
feat: centralize AI API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,15 @@ CVE Input → API Aggregation → AI Analysis → Risk Scoring → Decision Supp
 
 ---
 
+## 🔐 Environment Variables
+
+Create a `.env` file in the project root with the following variables to enable AI features:
+
+- `OPENAI_API_KEY` – OpenAI API key used for GPT models.
+- `GOOGLE_API_KEY` – Google Generative AI (Gemini) key. `GEMINI_API_KEY` is also supported.
+- `OPENAI_MODEL` *(optional)* – Override default OpenAI model.
+- `GEMINI_MODEL` *(optional)* – Override default Gemini model.
+
 ## 🤝 **Contributing**
 
 We welcome contributions to improve the Vulnerability Intelligence Platform:

--- a/cve_agent.tsx
+++ b/cve_agent.tsx
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import { getApiKeys } from './server/config/apiKeys';
 
 interface CVEReport {
   description: string;
@@ -13,12 +14,12 @@ interface CVEReport {
 }
 
 async function analyze(path: string) {
-  const apiKey = process.env.GOOGLE_API_KEY;
-  if (!apiKey) {
+  const { googleApiKey } = getApiKeys();
+  if (!googleApiKey) {
     throw new Error('GOOGLE_API_KEY environment variable not set');
   }
   const report: CVEReport = JSON.parse(fs.readFileSync(path, 'utf-8'));
-  const genAI = new GoogleGenerativeAI(apiKey);
+  const genAI = new GoogleGenerativeAI(googleApiKey);
   const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
 
   const prompt = `You are an expert cybersecurity analyst. Assess the following CVE report according to the CVE Validation & Legitimacy Analysis Framework.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default [
     },
   },
   {
-    files: ['server/*.js', 'test-env.js'],
+    files: ['server/**/*.js', 'test-env.js'],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.node,

--- a/server/config/apiKeys.js
+++ b/server/config/apiKeys.js
@@ -1,0 +1,31 @@
+/* eslint-env node */
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.resolve(__dirname, '../../.env');
+dotenv.config({ path: envPath });
+
+export function getApiKeys() {
+  return {
+    openAiApiKey: process.env.OPENAI_API_KEY,
+    googleApiKey: process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY,
+  };
+}
+
+export function getClientConfig() {
+  const { openAiApiKey, googleApiKey } = getApiKeys();
+  const hasOpenAI = !!openAiApiKey;
+  const hasGemini = !!googleApiKey;
+  const provider = hasOpenAI ? 'openai' : hasGemini ? 'gemini' : null;
+
+  return {
+    hasOpenAI,
+    hasGemini,
+    provider,
+    openAiModel: process.env.OPENAI_MODEL || 'gpt-4.1',
+    geminiModel: process.env.GEMINI_MODEL || 'gemini-2.5-flash',
+  };
+}

--- a/server/config/apiKeys.ts
+++ b/server/config/apiKeys.ts
@@ -1,0 +1,45 @@
+/* eslint-env node */
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Load environment variables from project root when this module is imported
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const envPath = path.resolve(__dirname, '../../.env');
+dotenv.config({ path: envPath });
+
+export interface ApiKeys {
+  openAiApiKey?: string;
+  googleApiKey?: string;
+}
+
+export function getApiKeys(): ApiKeys {
+  return {
+    openAiApiKey: process.env.OPENAI_API_KEY,
+    googleApiKey: process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY,
+  };
+}
+
+export interface ClientConfig {
+  hasOpenAI: boolean;
+  hasGemini: boolean;
+  provider: 'openai' | 'gemini' | null;
+  openAiModel: string;
+  geminiModel: string;
+}
+
+export function getClientConfig(): ClientConfig {
+  const { openAiApiKey, googleApiKey } = getApiKeys();
+  const hasOpenAI = !!openAiApiKey;
+  const hasGemini = !!googleApiKey;
+  const provider = hasOpenAI ? 'openai' : hasGemini ? 'gemini' : null;
+
+  return {
+    hasOpenAI,
+    hasGemini,
+    provider,
+    openAiModel: process.env.OPENAI_MODEL || 'gpt-4.1',
+    geminiModel: process.env.GEMINI_MODEL || 'gemini-2.5-flash',
+  };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,30 +1,14 @@
 import express from 'express';
 import fetch from 'node-fetch';
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { getApiKeys, getClientConfig } from './config/apiKeys.js';
 
-// Get the directory name in ES modules
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Load .env from project root (go up one directory from server folder)
-const envPath = path.resolve(__dirname, '..', '.env');
-const result = dotenv.config({ path: envPath });
-
-// Debug: Check if .env was loaded
-if (result.error) {
-  console.error('Error loading .env file:', result.error);
-  console.error('Looking for .env at:', envPath);
-} else {
-  console.log('Successfully loaded .env from:', envPath);
-  console.log('API Keys Status:');
-  console.log('- OPENAI_API_KEY:', process.env.OPENAI_API_KEY ? 'Set (length: ' + process.env.OPENAI_API_KEY.length + ')' : 'NOT SET');
-  console.log('- GEMINI_API_KEY:', process.env.GEMINI_API_KEY ? 'Set (length: ' + process.env.GEMINI_API_KEY.length + ')' : 'NOT SET');
-}
+const { openAiApiKey, googleApiKey } = getApiKeys();
+console.log('API Keys Status:');
+console.log('- OPENAI_API_KEY:', openAiApiKey ? 'Set' : 'NOT SET');
+console.log('- GOOGLE_API_KEY:', googleApiKey ? 'Set' : 'NOT SET');
 
 const app = express();
-app.use(express.json({limit: '10mb'}));
+app.use(express.json({ limit: '10mb' }));
 
 // Enable CORS for development
 app.use((req, res, next) => {
@@ -42,81 +26,74 @@ const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 
 app.post('/api/openai', async (req, res) => {
   console.log('OpenAI request received');
-  
-  if (!process.env.OPENAI_API_KEY) {
+
+  const { openAiApiKey } = getApiKeys();
+  if (!openAiApiKey) {
     console.error('OPENAI_API_KEY is not set!');
-    return res.status(500).json({error: 'OpenAI API key not configured'});
+    return res.status(500).json({ error: 'OpenAI API key not configured' });
   }
-  
+
   const endpoint = req.query.endpoint || 'chat/completions';
   const url = `${OPENAI_BASE}/${endpoint}`;
-  
+
   try {
     console.log('Making request to:', url);
     const resp = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+        'Authorization': `Bearer ${openAiApiKey}`
       },
       body: JSON.stringify(req.body)
     });
-    
+
     const text = await resp.text();
     console.log('OpenAI response status:', resp.status);
-    
+
     if (resp.status === 401) {
       console.error('Authentication failed - check your API key');
     }
-    
+
     res.status(resp.status).type('application/json').send(text);
   } catch (err) {
     console.error('OpenAI API error:', err);
-    res.status(500).json({error: err.message});
+    res.status(500).json({ error: err.message });
   }
 });
 
 app.post('/api/gemini', async (req, res) => {
   console.log('Gemini request received');
-  
-  if (!process.env.GEMINI_API_KEY) {
+
+  const { googleApiKey } = getApiKeys();
+  if (!googleApiKey) {
     console.error('GEMINI_API_KEY is not set!');
-    return res.status(500).json({error: 'Gemini API key not configured'});
+    return res.status(500).json({ error: 'Gemini API key not configured' });
   }
-  
+
   const model = req.query.model || 'gemini-2.0-flash-exp';
   const action = req.query.action || 'generateContent';
-  const url = `${GEMINI_BASE}/${model}:${action}?key=${process.env.GEMINI_API_KEY}`;
-  
+  const url = `${GEMINI_BASE}/${model}:${action}?key=${googleApiKey}`;
+
   try {
     console.log('Making request to Gemini model:', model);
     const resp = await fetch(url, {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req.body)
     });
-    
+
     const text = await resp.text();
     console.log('Gemini response status:', resp.status);
-    
+
     res.status(resp.status).type('application/json').send(text);
   } catch (err) {
     console.error('Gemini API error:', err);
-    res.status(500).json({error: err.message});
+    res.status(500).json({ error: err.message });
   }
 });
 
 app.get('/api/ai-config', (req, res) => {
-  const hasOpenAI = !!process.env.OPENAI_API_KEY;
-  const hasGemini = !!process.env.GEMINI_API_KEY;
-  const provider = hasOpenAI ? 'openai' : hasGemini ? 'gemini' : null;
-  res.json({
-    hasOpenAI,
-    hasGemini,
-    provider,
-    openAiModel: process.env.OPENAI_MODEL || 'gpt-4.1',
-    geminiModel: process.env.GEMINI_MODEL || 'gemini-2.5-flash'
-  });
+  res.json(getClientConfig());
 });
 
 const port = process.env.PORT || 3001;

--- a/src/components/AISourcesTab.tsx
+++ b/src/components/AISourcesTab.tsx
@@ -31,7 +31,6 @@ const AISourcesTab: React.FC<AISourcesTabProps> = ({ vulnerability }) => {
       const useGemini = settings.aiProvider === 'gemini';
       const result = await APIService.generateAITaintAnalysis(
         vulnerability,
-        '',
         useGemini ? settings.geminiModel : settings.openAiModel,
         settings
       );

--- a/src/components/CVEDetailView.tsx
+++ b/src/components/CVEDetailView.tsx
@@ -811,7 +811,6 @@ Focus on actionable information for security professionals.
       const useGemini = safeSettings.aiProvider === 'gemini';
       const result = await APIService.generateAIAnalysis(
         enhancedVulnerability,
-        '',
         useGemini ? safeSettings.geminiModel : safeSettings.openAiModel,
         safeSettings
       );

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -56,7 +56,7 @@ const EmptyState = () => {
         Real-time intelligence enhanced with semantic search, security sources, and domain expertise.
       </p>
 
-      {!settings.geminiApiKey && (
+      {!settings.aiProvider && (
         <div style={{
           marginTop: '32px',
           padding: '16px 20px',
@@ -91,7 +91,7 @@ const EmptyState = () => {
             color: settings.darkMode ? COLORS.dark.secondaryText : COLORS.light.secondaryText,
             lineHeight: 1.5
           }}>
-            Configure your Gemini API key in settings to enable AI-enhanced multi-source vulnerability analysis.
+            Configure AI provider settings to enable AI-enhanced multi-source vulnerability analysis.
           </p>
         </div>
       )}

--- a/src/services/AIEnhancementService.ts
+++ b/src/services/AIEnhancementService.ts
@@ -562,7 +562,6 @@ Provide specific information about any threats, exploits, or active usage you fi
  */
 export async function generateAIAnalysis(
   vulnerability: any,
-  apiKey: string,
   model: string,
   settings: any = {},
   ragDatabase: any,
@@ -588,7 +587,7 @@ export async function generateAIAnalysis(
   if (useGemini) window.lastGeminiRequest = now;
 
   if (ragDatabase) {
-    await ragDatabase.ensureInitialized(useGemini ? apiKey : null);
+    await ragDatabase.ensureInitialized();
     logger.debug(`📊 RAG Database Status: ${ragDatabase.documents.length} documents available`);
   }
 
@@ -928,7 +927,6 @@ export async function fetchGeneralAnswer(query: string, settings: any, fetchWith
  */
 export async function generateAITaintAnalysis(
   vulnerability: any,
-  apiKey: string,
   model: string,
   settings: any = {},
   fetchWithFallbackFn: any

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -65,12 +65,12 @@ export class APIService {
     return fetchWithCache(`threat-intel-${cveId}`, () => fetchAIThreatIntelligenceInternal(cveId, cveData, epssData, settings, setLoadingSteps, ragDatabase, fetchWithFallback, parseAIThreatIntelligence, performHeuristicAnalysis));
   }
 
-  static async generateAIAnalysis(vulnerability, apiKey, model, settings = {}) {
-    return fetchWithCache(`analysis-${vulnerability.cve.id}`, () => generateAIAnalysisInternal(vulnerability, apiKey, model, settings, ragDatabase, fetchWithFallback, buildEnhancedAnalysisPrompt, generateEnhancedFallbackAnalysis));
+  static async generateAIAnalysis(vulnerability, model, settings = {}) {
+    return fetchWithCache(`analysis-${vulnerability.cve.id}`, () => generateAIAnalysisInternal(vulnerability, model, settings, ragDatabase, fetchWithFallback, buildEnhancedAnalysisPrompt, generateEnhancedFallbackAnalysis));
   }
 
-  static async generateAITaintAnalysis(vulnerability, apiKey, model, settings = {}) {
-    return fetchWithCache(`taint-analysis-${vulnerability.cve.id}`, () => generateAITaintAnalysisInternal(vulnerability, apiKey, model, settings, fetchWithFallback));
+  static async generateAITaintAnalysis(vulnerability, model, settings = {}) {
+    return fetchWithCache(`taint-analysis-${vulnerability.cve.id}`, () => generateAITaintAnalysisInternal(vulnerability, model, settings, fetchWithFallback));
   }
 
   static async fetchGeneralAnswer(query, settings = {}) {


### PR DESCRIPTION
## Summary
- centralize loading of OpenAI and Gemini API keys in `server/config/apiKeys`
- refactor AI services and utilities to pull configuration via the new module and `/api/ai-config`
- document required AI provider environment variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c612da44832c996c7ce2ed334c75