### PR TITLE
feat: improve cybersecurity query classifier

### DIFF
--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -6,6 +6,28 @@ import { APIService } from '../services/APIService';
 const groundedResult = { content: 'grounded', sources: [], confidence: 0.9 };
 
 describe('CybersecurityAgent', () => {
+  it('classifies queries for cybersecurity relevance', () => {
+    const agent = new CybersecurityAgent();
+    const isRelated = (agent as any).isCybersecurityRelated;
+    expect(isRelated('Discuss ransomware trends')).toBe(true);
+    expect(isRelated('How do I bake a cake?')).toBe(false);
+  });
+
+  it('filters out non-security queries before searching', async () => {
+    const agent = new CybersecurityAgent();
+    const ragSpy = vi.spyOn(ragDatabase, 'search');
+    const webSpy = vi.spyOn(APIService, 'fetchGeneralAnswer');
+
+    const result = await agent.handleQuery('What is the weather today?');
+
+    expect(ragSpy).not.toHaveBeenCalled();
+    expect(webSpy).not.toHaveBeenCalled();
+    expect(result.text).toMatch(/cybersecurity/);
+
+    ragSpy.mockRestore();
+    webSpy.mockRestore();
+  });
+
   it('returns RAG result when confidence high and skips web search', async () => {
     const agent = new CybersecurityAgent();
     const ragSpy = vi

--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -161,17 +161,50 @@ export class CybersecurityAgent {
     const keywords = [
       'cve',
       'vulnerability',
+      'vulnerabilities',
       'exploit',
       'patch',
+      'patching',
       'malware',
       'cyber',
       'security',
       'kev',
       'epss',
-      'threat'
+      'threat',
+      'attack',
+      'intrusion',
+      'phishing',
+      'ransomware',
+      'zero day',
+      'zeroday',
+      'privilege escalation',
+      'botnet',
+      'ddos',
+      'denial of service',
+      'injection',
+      'sql injection',
+      'xss',
+      'cross site scripting',
+      'csrf',
+      'mitre',
+      'cisa',
+      'nvd',
+      'exploitdb',
+      'breach',
+      'leak',
+      'rootkit',
+      'worm',
+      'virus',
+      'payload',
+      'firewall',
+      'penetration test',
+      'pentest',
+      'red team'
     ];
-    const lower = query.toLowerCase();
-    return keywords.some(k => lower.includes(k));
+    const normalized = query
+      .toLowerCase()
+      .replace(/[^\w\s]/g, ' ');
+    return keywords.some(k => normalized.includes(k));
   }
 
   public async handleQuery(query: string): Promise<ChatResponse> {
@@ -199,40 +232,46 @@ export class CybersecurityAgent {
         return res;
       }
 
-      if (this.isCybersecurityRelated(query)) {
-        // First attempt to answer using the local RAG database
-        try {
-          const k = 5;
-          const ragResults = await ragDatabase.search(query, k);
-          const topMatch = ragResults[0];
-          const confidenceThreshold = 0.75;
-          if (topMatch && topMatch.similarity >= confidenceThreshold) {
-            return {
-              text: topMatch.content,
-              sender: 'bot',
-              id: Date.now().toString(),
-              confidence: topMatch.similarity,
-            };
-          }
-        } catch (e) {
-          console.error('RAG search failed', e);
-        }
+      if (!this.isCybersecurityRelated(query)) {
+        return {
+          text: `I'm designed to assist with cybersecurity topics. Please ask a security-related question.`,
+          sender: 'bot',
+          id: Date.now().toString(),
+        };
+      }
 
-        try {
-          const webResult = await APIService.fetchGeneralAnswer(
-            query,
-            this.settings || {}
-          );
-          if (webResult?.answer) {
-            return {
-              text: webResult.answer,
-              sender: 'bot',
-              id: Date.now().toString(),
-            };
-          }
-        } catch (e) {
-          console.error('Web search failed', e);
+      // First attempt to answer using the local RAG database
+      try {
+        const k = 5;
+        const ragResults = await ragDatabase.search(query, k);
+        const topMatch = ragResults[0];
+        const confidenceThreshold = 0.75;
+        if (topMatch && topMatch.similarity >= confidenceThreshold) {
+          return {
+            text: topMatch.content,
+            sender: 'bot',
+            id: Date.now().toString(),
+            confidence: topMatch.similarity,
+          };
         }
+      } catch (e) {
+        console.error('RAG search failed', e);
+      }
+
+      try {
+        const webResult = await APIService.fetchGeneralAnswer(
+          query,
+          this.settings || {}
+        );
+        if (webResult?.answer) {
+          return {
+            text: webResult.answer,
+            sender: 'bot',
+            id: Date.now().toString(),
+          };
+        }
+      } catch (e) {
+        console.error('Web search failed', e);
       }
 
       let response = `I understand you're asking about cybersecurity. `;


### PR DESCRIPTION
## Summary
- broaden cybersecurity keyword detection and normalize punctuation
- filter out non-security queries before RAG or web search
- test classification for security and non-security queries

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c939abcc832ca66896482c77d36b