### PR TITLE
Add bulk deduplication for CVE analysis results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useSettings } from './hooks/useSettings';
 import { ragDatabase } from './db/EnhancedVectorDatabase';
 import { AppContext } from './contexts/AppContext'; // Corrected import
 import { APIService } from './services/APIService'; // Added for bulk analysis
+import { dedupeResults, BulkAnalysisResult } from './analysis/BulkDeduplicator';
 
 // Main Application Component - Renamed from VulnerabilityIntelligence to App for main.jsx
 const App = () => {
@@ -35,7 +36,7 @@ const App = () => {
   const [showBulkUploadView, setShowBulkUploadView] = useState(false); // State for bulk upload UI
   
   // State for bulk analysis
-  const [bulkAnalysisResults, setBulkAnalysisResults] = useState<Array<{cveId: string, data?: any, error?: string}>>([]);
+  const [bulkAnalysisResults, setBulkAnalysisResults] = useState<BulkAnalysisResult[]>([]);
   const [isBulkLoading, setIsBulkLoading] = useState<boolean>(false);
   const [bulkProgress, setBulkProgress] = useState<{ current: number, total: number } | null>(null);
 
@@ -108,6 +109,9 @@ const App = () => {
 
       await utils.sleep(delayMs);
     }
+
+    const deduped = await dedupeResults(results);
+    setBulkAnalysisResults(deduped);
 
     setIsBulkLoading(false);
     setBulkProgress(null);

--- a/src/analysis/BulkDeduplicator.ts
+++ b/src/analysis/BulkDeduplicator.ts
@@ -1,0 +1,69 @@
+import { EnhancedVectorDatabase, ragDatabase } from '../db/EnhancedVectorDatabase';
+
+export interface BulkAnalysisResult {
+  cveId: string;
+  data?: any;
+  error?: string;
+  duplicates?: BulkAnalysisResult[];
+}
+
+/**
+ * Deduplicate analysis results by grouping CVEs with similar descriptions.
+ * Descriptions are embedded using EnhancedVectorDatabase.embedText and
+ * entries are grouped when cosine similarity exceeds the provided threshold.
+ */
+export async function dedupeResults(
+  results: BulkAnalysisResult[],
+  threshold = 0.9,
+  embedFn: (text: string) => Promise<number[]> = (EnhancedVectorDatabase as any).embedText
+    ? (EnhancedVectorDatabase as any).embedText.bind(EnhancedVectorDatabase)
+    : (text: string) => ragDatabase.createEmbedding(text)
+): Promise<BulkAnalysisResult[]> {
+  if (results.length === 0) return [];
+
+  const descriptions = results.map(r => r.data?.cve?.description || '');
+  const embeddings = await Promise.all(descriptions.map(d => embedFn(d)));
+
+  const n = results.length;
+  const parent = Array.from({ length: n }, (_, i) => i);
+
+  const find = (x: number): number => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  };
+
+  const union = (a: number, b: number) => {
+    const pa = find(a);
+    const pb = find(b);
+    if (pa !== pb) parent[pa] = pb;
+  };
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const sim = ragDatabase.cosineSimilarity(embeddings[i], embeddings[j]);
+      if (sim >= threshold) union(i, j);
+    }
+  }
+
+  const groups = new Map<number, number[]>();
+  for (let i = 0; i < n; i++) {
+    const root = find(i);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(i);
+  }
+
+  const deduped: BulkAnalysisResult[] = [];
+  for (const indices of groups.values()) {
+    const [first, ...rest] = indices;
+    const representative: BulkAnalysisResult = { ...results[first], duplicates: [] };
+    rest.forEach(idx => representative.duplicates!.push(results[idx]));
+    deduped.push(representative);
+  }
+
+  return deduped;
+}
+
+export default { dedupeResults };

--- a/src/analysis/__tests__/BulkDeduplicator.test.ts
+++ b/src/analysis/__tests__/BulkDeduplicator.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dedupeResults, BulkAnalysisResult } from '../BulkDeduplicator';
+
+const makeResult = (id: string, desc: string): BulkAnalysisResult => ({
+  cveId: id,
+  data: { cve: { description: desc } }
+});
+
+describe('BulkDeduplicator', () => {
+  it('groups results exceeding similarity threshold', async () => {
+    const results = [
+      makeResult('CVE-1', 'same'),
+      makeResult('CVE-2', 'same'),
+      makeResult('CVE-3', 'different')
+    ];
+
+    const embed = vi.fn()
+      .mockResolvedValueOnce([1, 0])
+      .mockResolvedValueOnce([1, 0])
+      .mockResolvedValueOnce([0, 1]);
+
+    const deduped = await dedupeResults(results, 0.9, embed);
+    expect(deduped.length).toBe(2);
+    const group = deduped.find(r => r.cveId === 'CVE-1');
+    expect(group?.duplicates?.length).toBe(1);
+    expect(group?.duplicates?.[0].cveId).toBe('CVE-2');
+  });
+
+  it('respects similarity threshold', async () => {
+    const results = [
+      makeResult('CVE-1', 'alpha'),
+      makeResult('CVE-2', 'beta')
+    ];
+
+    const embed = vi.fn()
+      .mockResolvedValueOnce([1, 0])
+      .mockResolvedValueOnce([0.86, 0.5]); // similarity ~0.86
+
+    const deduped = await dedupeResults(results, 0.9, embed);
+    expect(deduped.length).toBe(2);
+    expect(deduped[0].duplicates?.length).toBe(0);
+    expect(deduped[1].duplicates?.length).toBe(0);
+  });
+});

--- a/src/components/BulkUploadComponent.tsx
+++ b/src/components/BulkUploadComponent.tsx
@@ -7,10 +7,17 @@ import { extractCVEsFromCSV, extractCVEsFromPDF, extractCVEsFromXLSX } from '../
 import { utils } from '../utils/helpers'; // For severity color and level
 import { COLORS } from '../utils/constants'; // For direct color usage if needed
 
+interface BulkResult {
+  cveId: string;
+  data?: any;
+  error?: string;
+  duplicates?: BulkResult[];
+}
+
 interface BulkUploadComponentProps {
   onClose: () => void;
   startBulkAnalysis: (cveIds: string[]) => Promise<void>;
-  bulkAnalysisResults: Array<{cveId: string, data?: any, error?: string}>;
+  bulkAnalysisResults: BulkResult[];
   isBulkLoading: boolean;
   bulkProgress: { current: number, total: number } | null;
 }
@@ -210,6 +217,7 @@ const BulkUploadComponent: React.FC<BulkUploadComponentProps> = ({
                 const cveId = resultItem.cveId;
                 const resultData = resultItem.data; // This is EnhancedVulnerabilityData
                 const error = resultItem.error;
+                const duplicates = resultItem.duplicates || [];
 
                 let cvssScore: number | string = 'N/A';
                 let cvssSeverity: string = 'N/A';
@@ -283,6 +291,30 @@ const BulkUploadComponent: React.FC<BulkUploadComponentProps> = ({
                       </div>
                     ) : (
                       <div>No analysis data available.</div>
+                    )}
+
+                    {duplicates.length > 0 && (
+                      <details style={{ marginTop: '10px' }}>
+                        <summary style={{ cursor: 'pointer' }}>Duplicates ({duplicates.length})</summary>
+                        <ul style={{ marginTop: '6px', paddingLeft: '20px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                          {duplicates.map(dup => (
+                            <li key={dup.cveId} style={{ listStyle: 'disc' }}>
+                              {dup.error ? (
+                                <span style={{ color: COLORS.red }}>{dup.cveId} - {dup.error}</span>
+                              ) : (
+                                <a
+                                  href={utils.getVulnerabilityUrl(dup.cveId)}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  style={{ color: styles.app.color, textDecoration: 'none' }}
+                                >
+                                  {dup.cveId}
+                                </a>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
                     )}
                   </div>
                 );


### PR DESCRIPTION
## Summary
- Add BulkDeduplicator to embed CVE descriptions and group similar results
- Deduplicate bulk analysis output and surface duplicates in the UI
- Show duplicates via expandable lists in bulk analysis view
- Cover deduplication logic with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894cbe2a1c4832c94db444e2a16c79f