### PR TITLE
Resolve CVE aliases during bulk analysis

### DIFF
--- a/src/components/BulkUploadComponent.tsx
+++ b/src/components/BulkUploadComponent.tsx
@@ -10,7 +10,7 @@ import { COLORS } from '../utils/constants'; // For direct color usage if needed
 interface BulkUploadComponentProps {
   onClose: () => void;
   startBulkAnalysis: (cveIds: string[]) => Promise<void>;
-  bulkAnalysisResults: Array<{cveId: string, data?: any, error?: string}>;
+  bulkAnalysisResults: Array<{cveId: string, data?: any, error?: string, aliases?: string[]}>;
   isBulkLoading: boolean;
   bulkProgress: { current: number, total: number } | null;
 }

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -18,7 +18,7 @@ interface Message {
 
 interface ChatInterfaceProps {
   initialCveId?: string | null;
-  bulkAnalysisResults?: Array<{ cveId: string; data?: any; error?: string }>;
+  bulkAnalysisResults?: Array<{ cveId: string; data?: any; error?: string; aliases?: string[] }>;
 }
 
 const ChatInterface: React.FC<ChatInterfaceProps> = ({ initialCveId, bulkAnalysisResults = [] }) => {

--- a/src/services/__tests__/DataFetchingService.test.ts
+++ b/src/services/__tests__/DataFetchingService.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { resolveAliases } from '../DataFetchingService';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ghsaResponse = JSON.parse(
+  readFileSync(path.join(__dirname, 'fixtures/ghsa_response.json'), 'utf-8')
+);
+const cveResponse = JSON.parse(
+  readFileSync(path.join(__dirname, 'fixtures/cve_response.json'), 'utf-8')
+);
+
+describe('resolveAliases', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps non-CVE identifiers to canonical CVE and collects aliases', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(ghsaResponse)
+    }) as any;
+
+    const result = await resolveAliases('GHSA-xxxx-yyyy');
+    expect(global.fetch).toHaveBeenCalled();
+    expect(result.canonical).toBe('CVE-2024-1234');
+    expect(result.aliases).toEqual(expect.arrayContaining(['GHSA-xxxx-yyyy', 'CVE-2024-1234']));
+  });
+
+  it('returns aliases when starting from CVE id', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(cveResponse)
+    }) as any;
+
+    const result = await resolveAliases('CVE-2024-1234');
+    expect(result.canonical).toBe('CVE-2024-1234');
+    expect(result.aliases).toEqual(expect.arrayContaining(['GHSA-xxxx-yyyy', 'CVE-2024-1234']));
+  });
+});

--- a/src/services/__tests__/fixtures/cve_response.json
+++ b/src/services/__tests__/fixtures/cve_response.json
@@ -1,0 +1,4 @@
+{
+  "id": "CVE-2024-1234",
+  "aliases": ["GHSA-xxxx-yyyy"]
+}

--- a/src/services/__tests__/fixtures/ghsa_response.json
+++ b/src/services/__tests__/fixtures/ghsa_response.json
@@ -1,0 +1,4 @@
+{
+  "id": "GHSA-xxxx-yyyy",
+  "aliases": ["CVE-2024-1234", "ALIAS-1"]
+}

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -473,4 +473,5 @@ export interface BulkAnalysisResult {
   data?: EnhancedVulnerabilityData;
   error?: string;
   status: 'Pending' | 'Processing' | 'Complete' | 'Error';
+  aliases?: string[];
 }


### PR DESCRIPTION
## Summary
- add `resolveAliases` to look up canonical CVE IDs and alias lists via OSV
- merge alias identifiers to canonical IDs in `startBulkAnalysis`
- expose alias lists on bulk-analysis results and add fixture-based tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894cbe92458832ca1a3b8a56c867cb9