### PR TITLE
Expose grounding citations in agent responses

### DIFF
--- a/scripts/cybersecurity-agent-cli.ts
+++ b/scripts/cybersecurity-agent-cli.ts
@@ -37,6 +37,10 @@ rl.on('line', async line => {
   try {
     const res = await agent.handleQuery(input);
     console.log(res.text);
+    if (res.sources && res.sources.length > 0) {
+      console.log('\nSources:');
+      res.sources.forEach((s, i) => console.log(`${i + 1}. ${s}`));
+    }
   } catch (err: any) {
     console.error('Error:', err.message);
   }

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -14,6 +14,7 @@ interface Message {
   sender: 'user' | 'bot' | 'system';
   data?: any; // Optional structured data from bot
   error?: boolean;
+  sources?: string[];
 }
 
 interface ChatInterfaceProps {
@@ -94,6 +95,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ initialCveId, bulkAnalysi
         sender: 'bot',
         data: botResponse.data,
         error: !!botResponse.error,
+        sources: botResponse.sources,
       };
       setChatHistory(prev => [...prev, responseMessage]);
     } catch (error: any) {
@@ -173,6 +175,26 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({ initialCveId, bulkAnalysi
                 )}
               </div>
             </div>
+            {msg.sender === 'bot' && msg.sources && msg.sources.length > 0 && (
+              <div
+                style={{
+                  fontSize: '0.8rem',
+                  color:
+                    (settings.darkMode ? COLORS.dark.tertiaryText : COLORS.light.tertiaryText) || '#888',
+                  marginLeft: '32px',
+                  marginTop: '4px'
+                }}
+              >
+                Sources:
+                <ul style={{ margin: '4px 0 0 16px', padding: 0 }}>
+                  {msg.sources.map((src, idx) => (
+                    <li key={idx} style={{ marginBottom: '2px' }}>
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>{src}</ReactMarkdown>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             {msg.sender === 'bot' && msg.data && (
               <>
                 <div

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -468,6 +468,7 @@ export interface ChatResponse<T = any> {
   sender?: 'user' | 'bot' | 'system';
   confidence?: number;
   followUps?: string[];
+  sources?: string[];
 }
 
 export interface BulkAnalysisResult {


### PR DESCRIPTION
## Summary
- Collect source URLs from grounding metadata in AIGroundingEngine and attach to ChatResponse
- Surface citations from CybersecurityAgent replies and render them beneath bot messages
- Display source links in CLI output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689592960e48832cbc4d64ab6543f36b