### PR TITLE
feat: cache grounded search results

### DIFF
--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -97,6 +97,23 @@ describe('CybersecurityAgent', () => {
     expect(learnSpy).toHaveBeenCalledWith(groundedResult);
   });
 
+  it('caches grounding search results and allows manual refresh', async () => {
+    const agent = new CybersecurityAgent({
+      aiProvider: 'openai',
+      openAiModel: 'gpt-test',
+      groundingCacheTTL: 1000,
+    });
+    const searchSpy = vi.fn().mockResolvedValue(groundedResult);
+    (agent as any).groundingEngine = { search: searchSpy, learn: vi.fn() };
+
+    await (agent as any).getGroundedInfo('cache-query');
+    await (agent as any).getGroundedInfo('cache-query');
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+
+    await (agent as any).getGroundedInfo('cache-query', true);
+    expect(searchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('verifies CVE responses against known sources', async () => {
     const agent = new CybersecurityAgent();
     const ragSpy = vi.spyOn(ragDatabase, 'search').mockResolvedValue([]);

--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -158,6 +158,7 @@ export class CybersecurityAgent {
   private cache: Map<string, { data: any; timestamp: number }> = new Map();
   private readonly DEFAULT_CACHE_TTL = 300000; // 5 minutes
   private cacheTTL: number;
+  private groundingCacheTTL: number;
   private groundingEngine?: AIGroundingEngine;
   private groundingConfig?: AIGroundingConfig;
   private bulkAnalysisResults: BulkAnalysisResult[] | null = null;
@@ -165,6 +166,7 @@ export class CybersecurityAgent {
   constructor(settings?: AgentSettings) {
     this.settings = settings || {};
     this.cacheTTL = this.settings.cacheTTL ?? this.DEFAULT_CACHE_TTL;
+    this.groundingCacheTTL = this.settings.groundingCacheTTL ?? this.DEFAULT_CACHE_TTL;
 
     if (this.settings.aiProvider) {
       this.groundingConfig = { enableWebGrounding: true, autoLearn: true };
@@ -173,6 +175,16 @@ export class CybersecurityAgent {
         openai: this.settings.openAiApiKey,
       });
     }
+  }
+
+  private getGroundingModel(): string {
+    if (this.settings.aiProvider === 'openai') {
+      return this.settings.openAiModel || 'gpt-4.1';
+    }
+    if (this.settings.aiProvider === 'gemini') {
+      return this.settings.geminiModel || 'gemini-2.5-flash';
+    }
+    return 'unknown';
   }
 
   private isCybersecurityRelated(query: string): boolean {
@@ -225,7 +237,7 @@ export class CybersecurityAgent {
     return keywords.some(k => normalized.includes(k));
   }
 
-  public async handleQuery(query: string): Promise<ChatResponse> {
+  public async handleQuery(query: string, refreshCache = false): Promise<ChatResponse> {
     try {
       // Extract CVE ID from query
       const cveMatches = Array.from(query.matchAll(CVE_REGEX));
@@ -237,7 +249,7 @@ export class CybersecurityAgent {
       }
 
       if (operationalCveId) {
-        const res = await this.handleCVEQuery(query, operationalCveId);
+        const res = await this.handleCVEQuery(query, operationalCveId, refreshCache);
         try {
           const verification = await this.verifyResponse(
             operationalCveId,
@@ -306,7 +318,7 @@ export class CybersecurityAgent {
         }
       }
 
-      const grounded = await this.getGroundedInfo(query);
+      const grounded = await this.getGroundedInfo(query, refreshCache);
       if (grounded.sources.length > 0) {
         response.sources = grounded.sources.map((url, i) => `[Source ${i + 1}](${url})`);
       }
@@ -323,7 +335,11 @@ export class CybersecurityAgent {
     }
   }
 
-  private async handleCVEQuery(query: string, cveId: string): Promise<ChatResponse> {
+  private async handleCVEQuery(
+    query: string,
+    cveId: string,
+    refreshCache = false
+  ): Promise<ChatResponse> {
     try {
       // Future CVE warning
       const yearMatch = cveId.match(/CVE-(\d{4})-/);
@@ -341,7 +357,7 @@ export class CybersecurityAgent {
 
       // All CVE queries now go through the comprehensive report generator
       const result = await this.generateComprehensiveCVEReport(query, cveId);
-      const grounded = await this.getGroundedInfo(`${cveId} ${query}`);
+      const grounded = await this.getGroundedInfo(`${cveId} ${query}`, refreshCache);
       if (grounded.sources.length > 0) {
         result.sources = grounded.sources.map((url, i) => `[Source ${i + 1}](${url})`);
       }
@@ -358,14 +374,31 @@ export class CybersecurityAgent {
     }
   }
 
-  private async getGroundedInfo(query: string): Promise<GroundedSearchResult> {
+  private async getGroundedInfo(
+    query: string,
+    refreshCache = false
+  ): Promise<GroundedSearchResult> {
     if (!this.groundingEngine) {
       return { content: '', sources: [], confidence: 0 };
     }
+
+    const model = this.getGroundingModel();
+    const cacheKey = `ground:${model}:${query}`;
+
+    if (refreshCache) {
+      this.cache.delete(cacheKey);
+    } else {
+      const cached = this.cache.get(cacheKey);
+      if (cached && Date.now() - cached.timestamp < this.groundingCacheTTL) {
+        return cached.data;
+      }
+    }
+
     const result = await this.groundingEngine.search(query);
     if (this.groundingConfig?.autoLearn) {
       await this.groundingEngine.learn(result);
     }
+    this.cache.set(cacheKey, { data: result, timestamp: Date.now() });
     return result;
   }
 

--- a/src/types/cveData.ts
+++ b/src/types/cveData.ts
@@ -455,7 +455,8 @@ export interface AgentSettings {
   geminiModel?: string;
   openAiModel?: string;
   aiProvider?: 'gemini' | 'openai';
-  cacheTTL?: number; // TTL for caching in milliseconds
+  cacheTTL?: number; // TTL for general caching in milliseconds
+  groundingCacheTTL?: number; // TTL for grounding search cache
   [key: string]: any; // Allow other settings
 }
 


### PR DESCRIPTION
## Summary
- cache AIGroundingEngine search results keyed by model and query
- allow configurable TTL for grounded search cache via AgentSettings
- add manual refresh flag and tests for grounding cache

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689594aa36a0832cafd9d204fafb7379