### PR TITLE
fix(SearchResults): Add missing gray color to constants

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -33,6 +33,9 @@ export const COLORS = {
   green: '#22c55e',
   red: '#ef4444',
   yellow: '#f59e0b',
+  gray: {
+    500: '#64748b'
+  },
   dark: {
     background: '#0f172a',
     surface: '#1e293b',


### PR DESCRIPTION
- The SearchResults component was causing a crash because it was trying to access `COLORS.gray[500]`, but `COLORS.gray` was not defined in `src/utils/constants.ts`.
- This change adds the missing `gray` color object to the `COLORS` constant, resolving the runtime error.