### PR TITLE
I've implemented the missing chatbot commands you had documented.

### DIFF
--- a/src/agents/UserAssistantAgent.test.ts
+++ b/src/agents/UserAssistantAgent.test.ts
@@ -11,6 +11,26 @@ describe('UserAssistantAgent', () => {
     expect(result.text).toContain('cybersecurity assistant');
   });
 
+  it('handleQuery delegates to generateBulkAnalysisSummary for /bulk_summary', async () => {
+    const agent = new UserAssistantAgent();
+    const spy = vi
+      .spyOn(agent, 'generateBulkAnalysisSummary')
+      .mockReturnValue({ text: 'bulk summary', sender: 'bot', id: '1' });
+    await agent.handleQuery('/bulk_summary');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('handleQuery delegates to generateBulkComponentImpactSummary for /component_summary', async () => {
+    const agent = new UserAssistantAgent();
+    const spy = vi
+      .spyOn(agent, 'generateBulkComponentImpactSummary')
+      .mockReturnValue({ text: 'component summary', sender: 'bot', id: '1' });
+    await agent.handleQuery('/component_summary');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
   it('handleQuery delegates to handleCVEQuery when CVE present', async () => {
     const agent = new UserAssistantAgent();
     const spy = vi

--- a/src/agents/UserAssistantAgent.ts
+++ b/src/agents/UserAssistantAgent.ts
@@ -279,9 +279,16 @@ export class UserAssistantAgent {
   // Main query handler
   public async handleQuery(query: string): Promise<ChatResponse> {
     try {
+      const lowerQuery = query.toLowerCase().trim();
       // Handle special commands
-      if (query.toLowerCase().trim() === '/help') {
+      if (lowerQuery === '/help') {
         return this.generateHelpMessage();
+      }
+      if (lowerQuery === '/bulk_summary') {
+        return this.generateBulkAnalysisSummary();
+      }
+      if (lowerQuery === '/component_summary') {
+        return this.generateBulkComponentImpactSummary();
       }
 
       const analysis = this.analyzeQuery(query);


### PR DESCRIPTION
I noticed the `/bulk_summary` and `/component_summary` commands weren't being handled correctly. To fix this, I added logic to the `handleQuery` method to call the existing `generateBulkAnalysisSummary` and `generateBulkComponentImpactSummary` methods.

I also added new tests to `UserAssistantAgent.test.ts` to verify this functionality and prevent future regressions.