### PR TITLE
Add CISA KEV proxy endpoint and update data fetching

### DIFF
--- a/server/cisaKevProxy.js
+++ b/server/cisaKevProxy.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import fetch from 'node-fetch';
+const router = express.Router();
+const CISA_KEV_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+router.get('/api/cisa-kev', async (_req, res) => {
+    try {
+        const response = await fetch(CISA_KEV_URL);
+        const data = await response.text();
+        res.header('Access-Control-Allow-Origin', '*');
+        res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+        res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        res.status(response.status).type('application/json').send(data);
+    }
+    catch (err) {
+        res.header('Access-Control-Allow-Origin', '*');
+        res.status(500).json({ error: err.message });
+    }
+});
+export default router;

--- a/server/cisaKevProxy.ts
+++ b/server/cisaKevProxy.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import fetch from 'node-fetch';
+
+const router = express.Router();
+const CISA_KEV_URL = 'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+
+router.get('/api/cisa-kev', async (_req, res) => {
+  try {
+    const response = await fetch(CISA_KEV_URL);
+    const data = await response.text();
+
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
+
+    res.status(response.status).type('application/json').send(data);
+  } catch (err: any) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import fetch from 'node-fetch';
 import { getApiKeys, getClientConfig } from './config/apiKeys.js';
+import cisaKevProxy from './cisaKevProxy.js';
 
 const { openAiApiKey, googleApiKey } = getApiKeys();
 console.log('API Keys Status:');
@@ -23,6 +24,8 @@ app.use((req, res, next) => {
 
 const OPENAI_BASE = 'https://api.openai.com/v1';
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+app.use(cisaKevProxy);
 
 app.post('/api/openai', async (req, res) => {
   console.log('OpenAI request received');

--- a/src/services/DataFetchingService.ts
+++ b/src/services/DataFetchingService.ts
@@ -18,8 +18,7 @@ export function setGlobalAISettings(settings: any) {
 }
 
 // URLs for the CISA Known Exploited Vulnerabilities catalog
-const CISA_KEV_URL =
-  'https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json';
+const CISA_KEV_PROXY_URL = '/api/cisa-kev';
 const CISA_KEV_FALLBACK_URL =
   'https://raw.githubusercontent.com/cisagov/kev-data/develop/known_exploited_vulnerabilities.json';
 
@@ -284,13 +283,13 @@ async function parseAIWebSearchResponse(aiResponse: string, originalUrl: string,
 // ENHANCED CISA KEV parser
 async function fetchCisaKevCatalogData(): Promise<any> {
   try {
-    const response = await fetch(CISA_KEV_URL);
+    const response = await fetch(CISA_KEV_PROXY_URL);
     if (!response.ok) {
       throw new Error(`Failed to fetch CISA KEV catalog: ${response.status}`);
     }
     return await response.json();
   } catch (error) {
-    logger.warn('Primary CISA KEV fetch failed, using GitHub mirror', error);
+    logger.warn('Primary CISA KEV fetch via proxy failed, using GitHub mirror', error);
     const response = await fetch(CISA_KEV_FALLBACK_URL);
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
## Summary
- add Express proxy route for CISA KEV catalog with permissive CORS headers
- update server to register the new proxy route
- switch data fetching to use the proxy with GitHub mirror fallback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d479a5cc832c83731a9a6f131368