### PR TITLE
Expand cybersecurity agent capabilities

### DIFF
--- a/src/agents/CybersecurityAgent.test.ts
+++ b/src/agents/CybersecurityAgent.test.ts
@@ -10,6 +10,8 @@ describe('CybersecurityAgent', () => {
     const agent = new CybersecurityAgent();
     const isRelated = (agent as any).isCybersecurityRelated;
     expect(isRelated('Discuss ransomware trends')).toBe(true);
+    expect(isRelated('Explain risk management strategies')).toBe(true);
+    expect(isRelated('How should companies handle compliance policies?')).toBe(true);
     expect(isRelated('How do I bake a cake?')).toBe(false);
   });
 
@@ -22,7 +24,7 @@ describe('CybersecurityAgent', () => {
 
     expect(ragSpy).not.toHaveBeenCalled();
     expect(webSpy).not.toHaveBeenCalled();
-    expect(result.text).toMatch(/cybersecurity/);
+    expect(result.text).toMatch(/policy considerations/);
 
     ragSpy.mockRestore();
     webSpy.mockRestore();

--- a/src/agents/CybersecurityAgent.ts
+++ b/src/agents/CybersecurityAgent.ts
@@ -199,7 +199,18 @@ export class CybersecurityAgent {
       'firewall',
       'penetration test',
       'pentest',
-      'red team'
+      'red team',
+      'policy',
+      'policies',
+      'compliance',
+      'governance',
+      'risk',
+      'risk management',
+      'best practice',
+      'best practices',
+      'incident response',
+      'awareness',
+      'training'
     ];
     const normalized = query
       .toLowerCase()
@@ -234,7 +245,7 @@ export class CybersecurityAgent {
 
       if (!this.isCybersecurityRelated(query)) {
         return {
-          text: `I'm designed to assist with cybersecurity topics. Please ask a security-related question.`,
+          text: `Besides technical cybersecurity topics—like vulnerabilities, threat modeling, or secure architectures—I can also help with broader questions such as policy considerations, organizational best practices, risk management, or even general knowledge. Feel free to ask about anything you need clarified.`,
           sender: 'bot',
           id: Date.now().toString(),
         };


### PR DESCRIPTION
## Summary
- Broaden CybersecurityAgent keyword detection to cover policy, compliance, risk management, and training topics
- Update fallback message to highlight support for policy, best practices, and general knowledge
- Extend tests for new keywords and updated non-security query handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d86a40cc832cb07c2e315eee94a3