### PR TITLE
Add dual-model cybersecurity agent

### DIFF
--- a/src/agents/DualModelCybersecurityAgent.test.ts
+++ b/src/agents/DualModelCybersecurityAgent.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { DualModelCybersecurityAgent } from './DualModelCybersecurityAgent';
+
+describe('DualModelCybersecurityAgent', () => {
+  it('combines outputs from both models', async () => {
+    const agent = new DualModelCybersecurityAgent({
+      openAiConnector: async prompt => `OA:${prompt}`,
+      geminiConnector: async prompt => `G:${prompt}`,
+    });
+
+    const result = await agent.analyzeSecurity('test prompt');
+    expect(result).toContain('[OpenAI]');
+    expect(result).toContain('OA:test prompt');
+    expect(result).toContain('[Gemini]');
+    expect(result).toContain('G:test prompt');
+  });
+
+  it('works with a single model', async () => {
+    const agent = new DualModelCybersecurityAgent({
+      openAiConnector: async () => 'only openai',
+    });
+    const result = await agent.analyzeSecurity('hello');
+    expect(result).toContain('[OpenAI]');
+    expect(result).not.toContain('[Gemini]');
+  });
+});

--- a/src/agents/DualModelCybersecurityAgent.ts
+++ b/src/agents/DualModelCybersecurityAgent.ts
@@ -1,0 +1,92 @@
+import fetch from 'node-fetch';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+export type LLMConnector = (prompt: string) => Promise<string>;
+
+export function createOpenAIConnector(apiKey: string, model = 'gpt-4o-mini'): LLMConnector {
+  return async (prompt: string): Promise<string> => {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`OpenAI error: ${res.status} ${res.statusText}`);
+    }
+    const data: any = await res.json();
+    return data.choices?.[0]?.message?.content?.trim() || '';
+  };
+}
+
+export function createGeminiConnector(apiKey: string, model = 'gemini-pro'): LLMConnector {
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const geminiModel = genAI.getGenerativeModel({ model });
+  return async (prompt: string): Promise<string> => {
+    const result = await geminiModel.generateContent(prompt);
+    return result.response.text();
+  };
+}
+
+interface UserAgentOptions {
+  openAiConnector?: LLMConnector;
+  geminiConnector?: LLMConnector;
+}
+
+export class UserAssistantAgent {
+  constructor(private options: UserAgentOptions) {}
+
+  async run(prompt: string): Promise<Record<string, string>> {
+    const results: Record<string, string> = {};
+    if (this.options.openAiConnector) {
+      try {
+        results.openai = await this.options.openAiConnector(prompt);
+      } catch (e: any) {
+        results.openai_error = e.message || String(e);
+      }
+    }
+    if (this.options.geminiConnector) {
+      try {
+        results.gemini = await this.options.geminiConnector(prompt);
+      } catch (e: any) {
+        results.gemini_error = e.message || String(e);
+      }
+    }
+    return results;
+  }
+}
+
+interface AgentConfig {
+  openAiApiKey?: string;
+  geminiApiKey?: string;
+  openAiConnector?: LLMConnector;
+  geminiConnector?: LLMConnector;
+}
+
+export class DualModelCybersecurityAgent {
+  private userAgent: UserAssistantAgent;
+
+  constructor(config: AgentConfig) {
+    const openAi = config.openAiConnector ?? (config.openAiApiKey ? createOpenAIConnector(config.openAiApiKey) : undefined);
+    const gemini = config.geminiConnector ?? (config.geminiApiKey ? createGeminiConnector(config.geminiApiKey) : undefined);
+    this.userAgent = new UserAssistantAgent({ openAiConnector: openAi, geminiConnector: gemini });
+  }
+
+  async analyzeSecurity(prompt: string): Promise<string> {
+    const outputs = await this.userAgent.run(prompt);
+    const combined: string[] = [];
+    if (outputs.openai) {
+      combined.push(`[OpenAI]\n${outputs.openai}`);
+    }
+    if (outputs.gemini) {
+      combined.push(`[Gemini]\n${outputs.gemini}`);
+    }
+    return combined.join('\n\n') || 'No response from either model.';
+  }
+}
+

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -4,3 +4,4 @@ export * from './UserAssistantAgent';
 export * from './ValidationAgent';
 export * from './RiskAssessmentAgent';
 export * from './CybersecurityAgent';
+export * from './DualModelCybersecurityAgent';


### PR DESCRIPTION
## Summary
- expose new dual-model cybersecurity agent that queries both OpenAI and Gemini through a UserAssistantAgent
- include helpers to create OpenAI/Gemini connectors and return combined answers
- add tests for merging OpenAI and Gemini responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895e08b4bdc832cbc35e90ddad598bb