### PR TITLE
fix(build): Resolve build errors from conflicting exports and depende…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,6 +2551,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -2632,30 +2656,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {

--- a/src/agents/DualModelCybersecurityAgent.ts
+++ b/src/agents/DualModelCybersecurityAgent.ts
@@ -1,5 +1,6 @@
-import fetch from 'node-fetch';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+
+const fetch = typeof self === 'undefined' ? require('node-fetch') : self.fetch;
 
 export type LLMConnector = (prompt: string) => Promise<string>;
 
@@ -38,7 +39,7 @@ interface UserAgentOptions {
   geminiConnector?: LLMConnector;
 }
 
-export class UserAssistantAgent {
+class UserAssistantAgent {
   constructor(private options: UserAgentOptions) {}
 
   async run(prompt: string): Promise<Record<string, string>> {


### PR DESCRIPTION
…ncies

I found that the build was failing due to a `SyntaxError` caused by a name collision. Two separate modules were exporting components with the same name. I resolved this by making one of the components private to its module, which eliminated the conflict.

Additionally, I fixed another build failure caused by a dependency. A library intended for a Node.js environment was being incorrectly bundled for the browser. I've made the import conditional, so it is only included when running in a Node.js environment, and the browser's native functionality is used otherwise.