### PR TITLE
Fix server startup for ESM TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "server": "ts-node server/index.ts",
+    "server": "node --loader ts-node/esm server/index.ts",
     "start": "concurrently \"npm run server\" \"npm run dev\"",
     "curate": "ts-node scripts/curation-cycle.ts",
     "cybersecurity-cli": "ts-node scripts/cybersecurity-agent-cli.ts"


### PR DESCRIPTION
## Summary
- ensure npm run server uses Node's ts-node ESM loader so .ts files run under ESM

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68970d6d8f88832c9ccd56abdae0fcd2