### PR TITLE
fix: use local ts-node loader file for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "server": "node --import 'data:text/javascript,import {register} from \"node:module\";import {pathToFileURL} from \"node:url\";register(\"ts-node/esm\", pathToFileURL(\"./\"));' server/index.ts",
+    "server": "node --import ./register-ts-node.mjs server/index.ts",
     "start": "concurrently \"npm run server\" \"npm run dev\"",
     "curate": "ts-node scripts/curation-cycle.ts",
     "cybersecurity-cli": "ts-node scripts/cybersecurity-agent-cli.ts"

--- a/register-ts-node.mjs
+++ b/register-ts-node.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+register('ts-node/esm', pathToFileURL('./'));


### PR DESCRIPTION
## Summary
- avoid OS quoting issues by moving ts-node ESM registration into `register-ts-node.mjs`
- simplify server start script to import the local loader file

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971d6e51e8832cb0cfe65bc0fa637b